### PR TITLE
Typed rows via manual assembly

### DIFF
--- a/result.go
+++ b/result.go
@@ -1,14 +1,14 @@
 package sqlmock
 
 import (
-    "database/sql/driver"
+	"database/sql/driver"
 )
 
 // Result satisfies sql driver Result, which
 // holds last insert id and rows affected
 // by Exec queries
 type result struct {
-	insertID int64
+	insertID     int64
 	rowsAffected int64
 }
 

--- a/rows.go
+++ b/rows.go
@@ -40,17 +40,24 @@ func (r *rows) Next(dest []driver.Value) error {
 	return nil
 }
 
-func RowFromInterface(columns []string, values ...interface{}) driver.Rows {
-	rs := &rows{}
-	rs.cols = columns
+func (r *rows) AddRow(values ...interface{}) {
+	if len(values) != len(r.cols) {
+		panic("Expected number of values to match number of columns")
+	}
 
-	row := make([]driver.Value, len(columns))
+	row := make([]driver.Value, len(r.cols))
 	for i, v := range values {
 		row[i] = v
 	}
 
-	rs.rows = append(rs.rows, row)
+	r.rows = append(r.rows, row)
+}
 
+// NewRows allows Rows to be created manually to use
+// any of the types sql/driver.Value supports
+func NewRows(columns []string) *rows {
+	rs := &rows{}
+	rs.cols = columns
 	return rs
 }
 


### PR DESCRIPTION
Hey,

closes #1

I think this is a decent implementation as it allows for multiple rows to be added as a result with a fairly simple API.

Here's how it looks:

```
    rs := NewRows([]string{"id", "time", "a_boolean"})
    rs.AddRow(5, time.Now, true)

    ExpectQuery("SELECT (.+) FROM sales WHERE id = ?").
        WithArgs(5).
        WillReturnRows(rs)
```

Allowing rows to be generated by function calls could make a good future improvement, but I only need a single row for all my current tests and this works nicely.
