### PR TITLE
Optional argument expectations

### DIFF
--- a/expectations.go
+++ b/expectations.go
@@ -40,6 +40,9 @@ func (e *queryBasedExpectation) queryMatches(sql string) bool {
 }
 
 func (e *queryBasedExpectation) argsMatches(args []driver.Value) bool {
+	if nil == e.args {
+		return true
+	}
 	if len(args) != len(e.args) {
 		return false
 	}

--- a/expectations_test.go
+++ b/expectations_test.go
@@ -8,10 +8,14 @@ import (
 
 func TestQueryExpectationArgComparison(t *testing.T) {
 	e := &queryBasedExpectation{}
+	against := []driver.Value{5}
+	if !e.argsMatches(against) {
+		t.Error("arguments should match, since the no expectation was set")
+	}
+
 	e.args = []driver.Value{5, "str"}
 
-	against := []driver.Value{5}
-
+	against = []driver.Value{5}
 	if e.argsMatches(against) {
 		t.Error("arguments should not match, since the size is not the same")
 	}


### PR DESCRIPTION
Allow arguments to be bypassed when checking expectations.

Sometimes it's impossible to anticipate the args - such as in an insert
in which fields are generated in an unpredictable way.

Sometimes args don't need to be checked at all, as the focus of the test
is on a different aspect of the database/query.
