### PR TITLE
introduce MockConn type, which represents isolated connections

### DIFF
--- a/mock_connection.go
+++ b/mock_connection.go
@@ -20,6 +20,13 @@ type MockConn struct {
 	*conn
 }
 
+// ResetMockConns resets all registered MockConn instances
+func ResetMockConns() {
+	mutex.Lock()
+	mockConnections = make(map[string]*MockConn)
+	mutex.Unlock()
+}
+
 // NewMockConn creates a new mock connection instance
 //
 // Instances are identified using an ID string. You can pass the expected ID as a DSN

--- a/mock_connection.go
+++ b/mock_connection.go
@@ -1,0 +1,119 @@
+package sqlmock
+
+import (
+	"fmt"
+	"regexp"
+	"sync"
+)
+
+var (
+	mutex           sync.RWMutex
+	mockConnections = make(map[string]*MockConn)
+)
+
+// MockConn is a mocked connection for database/sql
+//
+// It is a (database/sql/driver).Conn, so it can be used just like a normal connection
+//
+// Apply the expectations to the MockConn
+type MockConn struct {
+	*conn
+}
+
+// NewMockConn creates a new mock connection instance
+//
+// Instances are identified using an ID string. You can pass the expected ID as a DSN
+// like so:
+//
+//   db, err := sql.Open("mock", "id=instance_id")
+//
+// IDs are unique, creating a new mock conn when the ID is already present will
+// end in an error.
+func NewMockConn(ID string) (*MockConn, error) {
+	mutex.Lock()
+	defer mutex.Unlock()
+	if _, ok := mockConnections[ID]; ok {
+		return nil, fmt.Errorf("there is already a connection with the ID %s", ID)
+	}
+	c := &MockConn{conn: &conn{}}
+	mockConnections[ID] = c
+	return c, nil
+}
+
+func mockConn(ID string) (*MockConn, error) {
+	mutex.RLock()
+	defer mutex.RUnlock()
+	if conn, ok := mockConnections[ID]; ok {
+		return conn, nil
+	} else {
+		return nil, fmt.Errorf("no connection with ID %s", ID)
+	}
+}
+
+// ExpectBegin expects transaction to be started
+func (mock *MockConn) ExpectBegin() Mock {
+	e := &expectedBegin{}
+	mock.conn.expectations = append(mock.conn.expectations, e)
+	mock.conn.active = e
+	return mock.conn
+}
+
+// ExpectCommit expects transaction to be commited
+func (mock *MockConn) ExpectCommit() Mock {
+	e := &expectedCommit{}
+	mock.conn.expectations = append(mock.conn.expectations, e)
+	mock.conn.active = e
+	return mock.conn
+}
+
+// ExpectRollback expects transaction to be rolled back
+func (mock *MockConn) ExpectRollback() Mock {
+	e := &expectedRollback{}
+	mock.conn.expectations = append(mock.conn.expectations, e)
+	mock.conn.active = e
+	return mock.conn
+}
+
+// ExpectPrepare expects Query to be prepared
+func (mock *MockConn) ExpectPrepare() Mock {
+	e := &expectedPrepare{}
+	mock.conn.expectations = append(mock.conn.expectations, e)
+	mock.conn.active = e
+	return mock.conn
+}
+
+// ExpectExec expects database Exec to be triggered, which will match
+// the given query string as a regular expression
+func (mock *MockConn) ExpectExec(sqlRegexStr string) Mock {
+	e := &expectedExec{}
+	e.sqlRegex = regexp.MustCompile(sqlRegexStr)
+	mock.conn.expectations = append(mock.conn.expectations, e)
+	mock.conn.active = e
+	return mock.conn
+}
+
+// ExpectQuery database Query to be triggered, which will match
+// the given query string as a regular expression
+func (mock *MockConn) ExpectQuery(sqlRegexStr string) Mock {
+	e := &expectedQuery{}
+	e.sqlRegex = regexp.MustCompile(sqlRegexStr)
+
+	mock.conn.expectations = append(mock.conn.expectations, e)
+	mock.conn.active = e
+	return mock.conn
+}
+
+// Close a mock database driver connection. It should
+// be always called to ensure that all expectations
+// were met successfully. Returns error if there is any
+func (mock *MockConn) Close() (err error) {
+	for _, e := range mock.conn.expectations {
+		if !e.fulfilled() {
+			err = fmt.Errorf("there is a remaining expectation %T which was not matched yet", e)
+			break
+		}
+	}
+	mock.conn.expectations = []expectation{}
+	mock.conn.active = nil
+	return err
+}

--- a/mock_connection_test.go
+++ b/mock_connection_test.go
@@ -7,30 +7,21 @@ import (
 )
 
 func TestDatabaseSQLReturnsCorrectInstances(t *testing.T) {
-	mockOne, err := NewMockConn("one")
+	mockOneID, mockOne, err := NewMockConn()
 	if err != nil {
 		t.Errorf("got error on init conn: %v", err)
 		return
 	}
-	mockTwo, err := NewMockConn("two")
+	mockTwoID, mockTwo, err := NewMockConn()
 	if err != nil {
 		t.Errorf("got error on init conn: %v", err)
-		return
-	}
-	_, err = NewMockConn("one")
-	if err == nil {
-		t.Error("expect error on requesting same id, got nil instead")
-		return
-	}
-	if !strings.Contains(err.Error(), "already a connection") {
-		t.Errorf("expect error message hinting at already existing connection. got %s", err.Error())
 		return
 	}
 
 	mockOne.ExpectQuery("SELECT one").WillReturnRows(NewRows([]string{"one"}).AddRow("one"))
 	mockTwo.ExpectQuery("SELECT two").WillReturnRows(NewRows([]string{"two"}).AddRow("two"))
 
-	dbOne, err := sql.Open("mock", "id=one")
+	dbOne, err := sql.Open("mock", "id="+mockOneID)
 	if err != nil {
 		t.Errorf("expect db one to be returned, got error instead: %v", err)
 		return
@@ -40,7 +31,7 @@ func TestDatabaseSQLReturnsCorrectInstances(t *testing.T) {
 		t.Errorf("error on ping db one: %v", err)
 		return
 	}
-	dbTwo, err := sql.Open("mock", "id=two")
+	dbTwo, err := sql.Open("mock", "id="+mockTwoID)
 	if err != nil {
 		t.Errorf("expect db two to be returned, got error instead: %v", err)
 		return

--- a/mock_connection_test.go
+++ b/mock_connection_test.go
@@ -27,8 +27,8 @@ func TestDatabaseSQLReturnsCorrectInstances(t *testing.T) {
 		return
 	}
 
-	mockOne.ExpectQuery("SELECT one").WillReturnRows(NewRows([]string{"one"}))
-	mockTwo.ExpectQuery("SELECT two").WillReturnRows(NewRows([]string{"two"}))
+	mockOne.ExpectQuery("SELECT one").WillReturnRows(NewRows([]string{"one"}).AddRow("one"))
+	mockTwo.ExpectQuery("SELECT two").WillReturnRows(NewRows([]string{"two"}).AddRow("two"))
 
 	dbOne, err := sql.Open("mock", "id=one")
 	if err != nil {

--- a/mock_connection_test.go
+++ b/mock_connection_test.go
@@ -1,0 +1,78 @@
+package sqlmock
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+)
+
+func TestDatabaseSQLReturnsCorrectInstances(t *testing.T) {
+	mockOne, err := NewMockConn("one")
+	if err != nil {
+		t.Errorf("got error on init conn: %v", err)
+		return
+	}
+	mockTwo, err := NewMockConn("two")
+	if err != nil {
+		t.Errorf("got error on init conn: %v", err)
+		return
+	}
+	_, err = NewMockConn("one")
+	if err == nil {
+		t.Error("expect error on requesting same id, got nil instead")
+		return
+	}
+	if !strings.Contains(err.Error(), "already a connection") {
+		t.Errorf("expect error message hinting at already existing connection. got %s", err.Error())
+		return
+	}
+
+	mockOne.ExpectQuery("SELECT one")
+	mockTwo.ExpectQuery("SELECT two")
+
+	dbOne, err := sql.Open("mock", "id=one")
+	if err != nil {
+		t.Errorf("expect db one to be returned, got error instead: %v", err)
+		return
+	}
+	err = dbOne.Ping()
+	if err != nil {
+		t.Errorf("error on ping db one: %v", err)
+		return
+	}
+	dbTwo, err := sql.Open("mock", "id=two")
+	if err != nil {
+		t.Errorf("expect db two to be returned, got error instead: %v", err)
+		return
+	}
+	err = dbTwo.Ping()
+	if err != nil {
+		t.Errorf("error on ping db two: %v", err)
+	}
+	d, err := sql.Open("mock", "id=three")
+	if err != nil {
+		t.Errorf("error on open nonexistent mock: %v", err)
+	}
+	err = d.Ping()
+	if err == nil {
+		t.Errorf("expect nonexistent mock request to return error, got nil instead with %+v.", d)
+		return
+	}
+	if !strings.Contains(err.Error(), "no connection with ID") {
+		t.Errorf("expect error message hinting at wrong id. got message: %s", err.Error())
+		return
+	}
+
+	for id, db := range map[string]*sql.DB{"one": dbOne, "two": dbTwo} {
+		go func(id string, db *sql.DB) {
+			_, err := db.Query("SELECT " + id)
+			if err != nil {
+				t.Errorf("error on query: %v", err)
+			}
+			err = db.Close()
+			if err != nil {
+				t.Errorf("error on db close (id %s): %v", id, err)
+			}
+		}(id, db)
+	}
+}

--- a/sqlmock.go
+++ b/sqlmock.go
@@ -57,6 +57,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
+	"net/url"
 	"regexp"
 )
 
@@ -77,6 +78,15 @@ type mockDriver struct {
 }
 
 func (d *mockDriver) Open(dsn string) (driver.Conn, error) {
+	if dsn != "" {
+		params, err := url.ParseQuery(dsn)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing DSN: %v", err)
+		}
+		if params.Get("id") != "" {
+			return mockConn(params.Get("id"))
+		}
+	}
 	return mock.conn, nil
 }
 


### PR DESCRIPTION
Hi, this is an attempt to isolate connections for parallel testing. Coincidentally I had to solve this issue for myself as well.

Since the `sql.Open()` does a whole lot more than just passing a `driver.Conn` I had to identify instances using IDs and passing them in the DSN.

Should help with #9 
