### PR TITLE
Wildcard string match for WithArgs

### DIFF
--- a/expectations.go
+++ b/expectations.go
@@ -76,8 +76,8 @@ func (e *queryBasedExpectation) argsMatches(args []driver.Value) bool {
 				return false
 			}
 		case reflect.String:
-			if vi.String() != ai.String() {
-				return false
+			if ai.String() != ".+" && vi.String() != ai.String() {
+			   	       	  return false
 			}
 		default:
 			// compare types like time.Time based on type only

--- a/expectations.go
+++ b/expectations.go
@@ -77,7 +77,7 @@ func (e *queryBasedExpectation) argsMatches(args []driver.Value) bool {
 			}
 		case reflect.String:
 			if ai.String() != ".+" && vi.String() != ai.String() {
-			   	       	  return false
+				return false
 			}
 		default:
 			// compare types like time.Time based on type only

--- a/expectations_test.go
+++ b/expectations_test.go
@@ -38,6 +38,11 @@ func TestQueryExpectationArgComparison(t *testing.T) {
 		t.Error("arguments should not match, since the second argument (string value) is different")
 	}
 
+	against = []driver.Value{5, ".+"}
+	if e.argsMatches(against) {
+		t.Error("args should match, since the second argument is a wildcard")
+	}	
+
 	against = []driver.Value{5, "str"}
 	if !e.argsMatches(against) {
 		t.Error("arguments should match, but it did not")

--- a/expectations_test.go
+++ b/expectations_test.go
@@ -38,11 +38,6 @@ func TestQueryExpectationArgComparison(t *testing.T) {
 		t.Error("arguments should not match, since the second argument (string value) is different")
 	}
 
-	against = []driver.Value{5, ".+"}
-	if e.argsMatches(against) {
-		t.Error("args should match, since the second argument is a wildcard")
-	}	
-
 	against = []driver.Value{5, "str"}
 	if !e.argsMatches(against) {
 		t.Error("arguments should match, but it did not")
@@ -57,10 +52,17 @@ func TestQueryExpectationArgComparison(t *testing.T) {
 	if !e.argsMatches(against) {
 		t.Error("arguments should match (time will be compared only by type), but it did not")
 	}
-
+	
 	against = []driver.Value{5, matcher{}}
 	if !e.argsMatches(against) {
 		t.Error("arguments should match, but it did not")
+	}
+
+	e = &queryBasedExpectation{}
+	e.args = []driver.Value{5, ".+"}
+	against = []driver.Value{5, "stuff"}
+	if !e.argsMatches(against) {
+		t.Error("arguments should match, since the second argument is a wildcard")
 	}
 }
 

--- a/expectations_test.go
+++ b/expectations_test.go
@@ -52,7 +52,7 @@ func TestQueryExpectationArgComparison(t *testing.T) {
 	if !e.argsMatches(against) {
 		t.Error("arguments should match (time will be compared only by type), but it did not")
 	}
-	
+
 	against = []driver.Value{5, matcher{}}
 	if !e.argsMatches(against) {
 		t.Error("arguments should match, but it did not")


### PR DESCRIPTION
If a query inserts a random string into a table I'd like to be able to add the WithArgs arg of '.+' and whatever string will match that arg.