### PR TITLE
Add bool type to query arg matcher

### DIFF
--- a/expectations.go
+++ b/expectations.go
@@ -358,6 +358,10 @@ func (e *queryBasedExpectation) argsMatches(args []driver.Value) bool {
 			if vi.String() != ai.String() {
 				return false
 			}
+		case reflect.Bool:
+			if vi.Bool() != ai.Bool() {
+				return false
+			}
 		default:
 			// compare types like time.Time based on type only
 			if vi.Kind() != ai.Kind() {

--- a/expectations_test.go
+++ b/expectations_test.go
@@ -60,8 +60,37 @@ func TestQueryExpectationArgComparison(t *testing.T) {
 	}
 }
 
+func TestQueryExpectationArgComparisonBool(t *testing.T) {
+	var e *queryBasedExpectation
+
+	e = &queryBasedExpectation{args: []driver.Value{true}}
+	against := []driver.Value{true}
+	if !e.argsMatches(against) {
+		t.Error("arguments should match, since arguments are the same")
+	}
+
+	e = &queryBasedExpectation{args: []driver.Value{false}}
+	against = []driver.Value{false}
+	if !e.argsMatches(against) {
+		t.Error("arguments should match, since argument are the same")
+	}
+
+	e = &queryBasedExpectation{args: []driver.Value{true}}
+	against = []driver.Value{false}
+	if e.argsMatches(against) {
+		t.Error("arguments should not match, since argument is different")
+	}
+
+	e = &queryBasedExpectation{args: []driver.Value{false}}
+	against = []driver.Value{true}
+	if e.argsMatches(against) {
+		t.Error("arguments should not match, since argument is different")
+	}
+}
+
 func TestQueryExpectationSqlMatch(t *testing.T) {
 	e := &ExpectedExec{}
+
 	e.sqlRegex = regexp.MustCompile("SELECT x FROM")
 	if !e.queryMatches("SELECT x FROM someting") {
 		t.Errorf("Sql must have matched the query")


### PR DESCRIPTION
It was missing there. Could we also use reflect.deepequal to compare other types?