### PR TITLE
Matching prepared statements to regexp + optional expectations

### DIFF
--- a/expectations.go
+++ b/expectations.go
@@ -19,9 +19,11 @@ type Argument interface {
 // an expectation interface
 type expectation interface {
 	fulfilled() bool
+	check() bool
 	Lock()
 	Unlock()
 	String() string
+	Optional()
 }
 
 // common expectation struct
@@ -30,10 +32,19 @@ type commonExpectation struct {
 	sync.Mutex
 	triggered bool
 	err       error
+	optional bool
 }
 
 func (e *commonExpectation) fulfilled() bool {
 	return e.triggered
+}
+
+func (e *commonExpectation) check() bool {
+	return e.triggered || e.optional
+}
+
+func (e *commonExpectation) Optional() {
+	e.optional = true
 }
 
 // ExpectedClose is used to manage *sql.DB.Close expectation


### PR DESCRIPTION
I've added some features I needed while using your library. Haven't checked even if that code is correct ;) Consider merging this or adding such functionality on your own.