### PR TITLE
Add time.Time parsing to FromCSVString

### DIFF
--- a/rows.go
+++ b/rows.go
@@ -5,17 +5,20 @@ import (
 	"encoding/csv"
 	"io"
 	"strings"
+	"time"
 )
 
 // CSVColumnParser is a function which converts trimmed csv
 // column string to a []byte representation. currently
 // transforms NULL to nil
-var CSVColumnParser = func(s string) []byte {
-	switch {
-	case strings.ToLower(s) == "null":
+var CSVColumnParser = func(s string) driver.Value {
+	if strings.ToLower(s) == "null" {
 		return nil
+	} else if p, err := time.Parse("2006-01-02T15:04:05", s); err == nil {
+		return p
+	} else {
+		return []byte(s)
 	}
-	return []byte(s)
 }
 
 // Rows interface allows to construct rows

--- a/rows_test.go
+++ b/rows_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"testing"
+	"time"
 )
 
 func ExampleRows() {
@@ -218,7 +219,8 @@ func TestRowsScanError(t *testing.T) {
 
 func TestCSVRowParser(t *testing.T) {
 	t.Parallel()
-	rs := NewRows([]string{"col1", "col2"}).FromCSVString("a,NULL")
+	rs := NewRows([]string{"col1", "col2", "col3"}).FromCSVString(
+		"a,NULL,2016-05-09T14:59:03")
 	db, mock, err := New()
 	if err != nil {
 		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
@@ -234,9 +236,10 @@ func TestCSVRowParser(t *testing.T) {
 	defer rw.Close()
 	var col1 string
 	var col2 []byte
+	var col3 time.Time
 
 	rw.Next()
-	if err = rw.Scan(&col1, &col2); err != nil {
+	if err = rw.Scan(&col1, &col2, &col3); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 	if col1 != "a" {
@@ -244,5 +247,8 @@ func TestCSVRowParser(t *testing.T) {
 	}
 	if col2 != nil {
 		t.Fatalf("expected col2 to be nil, but got [%T]:%+v", col2, col2)
+	}
+	if col3 != time.Date(2016, time.May, 9, 14, 59, 3, 0, time.UTC) {
+		t.Fatalf("expected col3 to be 2016-05-09T14:59:03, but got [%T]:%+v", col3, col3)
 	}
 }


### PR DESCRIPTION
Right now, it's very cumbersome to mock rows with dates in them if you want to `Scan` them into a `time.Time`. You have to do something like

    mock.ExpectQuery("select created_at from table where id = \\$2")
      .WithArgs("1").WillReturnRows(sqlmock.NewRows(columns)
      .AddRow(time.Date(2015, time.December, 24, 14, 0, 0, 0, time.UTC)))

With this PR, a CSV column on the format `2016-05-09T14:59:03` is parsed as a `time.Time`. This enables you to do

    mock.ExpectQuery("select created_at from table where id = \\$2")
      .WithArgs("1").WillReturnRows(sqlmock.NewRows(columns)
      .FromCSVString("2015-12-24T14:00:00"))
