### PR TITLE
Build query before regex

### DIFF
--- a/expectations_test.go
+++ b/expectations_test.go
@@ -103,3 +103,27 @@ func ExampleExpectedExec() {
 	fmt.Println(err)
 	// Output: some error
 }
+
+func TestBuildQuery(t *testing.T){
+	db, mock, _ := New()
+	query := `
+		SELECT
+			name,
+			email,
+			address,
+			anotherfield
+		FROM user
+	`
+	
+	mock.ExpectQuery(query)
+	mock.ExpectExec(query)
+	mock.ExpectPrepare(query)
+	
+	db.QueryRow(query)
+	db.Exec(query)
+	db.Prepare(query)
+	
+	if err:=mock.ExpectationsWereMet(); err!=nil{
+		t.Error(err)
+	}
+}

--- a/sqlmock.go
+++ b/sqlmock.go
@@ -255,6 +255,7 @@ func (c *sqlmock) Exec(query string, args []driver.Value) (res driver.Result, er
 
 func (c *sqlmock) ExpectExec(sqlRegexStr string) *ExpectedExec {
 	e := &ExpectedExec{}
+	sqlRegexStr = buildQuery(sqlRegexStr)
 	e.sqlRegex = regexp.MustCompile(sqlRegexStr)
 	c.expected = append(c.expected, e)
 	return e
@@ -301,6 +302,7 @@ func (c *sqlmock) Prepare(query string) (driver.Stmt, error) {
 }
 
 func (c *sqlmock) ExpectPrepare(sqlRegexStr string) *ExpectedPrepare {
+	sqlRegexStr = buildQuery(sqlRegexStr)
 	e := &ExpectedPrepare{sqlRegex: regexp.MustCompile(sqlRegexStr), mock: c}
 	c.expected = append(c.expected, e)
 	return e
@@ -369,6 +371,7 @@ func (c *sqlmock) Query(query string, args []driver.Value) (rw driver.Rows, err 
 
 func (c *sqlmock) ExpectQuery(sqlRegexStr string) *ExpectedQuery {
 	e := &ExpectedQuery{}
+	sqlRegexStr = buildQuery(sqlRegexStr)
 	e.sqlRegex = regexp.MustCompile(sqlRegexStr)
 	c.expected = append(c.expected, e)
 	return e

--- a/util.go
+++ b/util.go
@@ -11,3 +11,14 @@ var re = regexp.MustCompile("\\s+")
 func stripQuery(q string) (s string) {
 	return strings.TrimSpace(re.ReplaceAllString(q, " "))
 }
+
+// mimicking how sql.DB build their queries
+func buildQuery(q string)string{
+	q = strings.TrimSpace(q)
+	lines := strings.Split(q,"\n")
+	var newQuery string
+	for _,l := range lines{
+		newQuery = newQuery +" " +strings.TrimSpace(l)
+	}
+	return strings.TrimSpace(newQuery)
+}


### PR DESCRIPTION
build query before regex, mimicking how sql.DB build their query