### PR TITLE
apply stripQuery before assigning query expectation

### DIFF
--- a/expectations_test.go
+++ b/expectations_test.go
@@ -104,7 +104,7 @@ func ExampleExpectedExec() {
 	// Output: some error
 }
 
-func TestBuildQuery(t *testing.T){
+func TestBuildQuery(t *testing.T) {
 	db, mock, _ := New()
 	query := `
 		SELECT
@@ -113,17 +113,22 @@ func TestBuildQuery(t *testing.T){
 			address,
 			anotherfield
 		FROM user
+		where
+			name    = 'John'
+			and
+			address = 'Jakarta'
+		
 	`
-	
+
 	mock.ExpectQuery(query)
 	mock.ExpectExec(query)
 	mock.ExpectPrepare(query)
-	
+
 	db.QueryRow(query)
 	db.Exec(query)
 	db.Prepare(query)
-	
-	if err:=mock.ExpectationsWereMet(); err!=nil{
+
+	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Error(err)
 	}
 }

--- a/sqlmock.go
+++ b/sqlmock.go
@@ -255,7 +255,7 @@ func (c *sqlmock) Exec(query string, args []driver.Value) (res driver.Result, er
 
 func (c *sqlmock) ExpectExec(sqlRegexStr string) *ExpectedExec {
 	e := &ExpectedExec{}
-	sqlRegexStr = buildQuery(sqlRegexStr)
+	sqlRegexStr = stripQuery(sqlRegexStr)
 	e.sqlRegex = regexp.MustCompile(sqlRegexStr)
 	c.expected = append(c.expected, e)
 	return e
@@ -302,7 +302,7 @@ func (c *sqlmock) Prepare(query string) (driver.Stmt, error) {
 }
 
 func (c *sqlmock) ExpectPrepare(sqlRegexStr string) *ExpectedPrepare {
-	sqlRegexStr = buildQuery(sqlRegexStr)
+	sqlRegexStr = stripQuery(sqlRegexStr)
 	e := &ExpectedPrepare{sqlRegex: regexp.MustCompile(sqlRegexStr), mock: c}
 	c.expected = append(c.expected, e)
 	return e
@@ -371,7 +371,7 @@ func (c *sqlmock) Query(query string, args []driver.Value) (rw driver.Rows, err 
 
 func (c *sqlmock) ExpectQuery(sqlRegexStr string) *ExpectedQuery {
 	e := &ExpectedQuery{}
-	sqlRegexStr = buildQuery(sqlRegexStr)
+	sqlRegexStr = stripQuery(sqlRegexStr)
 	e.sqlRegex = regexp.MustCompile(sqlRegexStr)
 	c.expected = append(c.expected, e)
 	return e

--- a/sqlmock_test.go
+++ b/sqlmock_test.go
@@ -3,17 +3,17 @@ package sqlmock
 import (
 	"database/sql"
 	"fmt"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
-	"github.com/golang/go/src/pkg/strconv"
 )
 
 func cancelOrder(db *sql.DB, orderID int) error {
 	tx, _ := db.Begin()
 	_, _ = tx.Query("SELECT * FROM orders {0} FOR UPDATE", orderID)
 	err := tx.Rollback()
-	if (err != nil) {
+	if err != nil {
 		return err
 	}
 	return nil
@@ -892,8 +892,8 @@ func TestPrepareExec(t *testing.T) {
 	defer db.Close()
 	mock.ExpectBegin()
 	ep := mock.ExpectPrepare("INSERT INTO ORDERS\\(ID, STATUS\\) VALUES \\(\\?, \\?\\)")
-	for i:=0; i < 3; i++ {
-		ep.ExpectExec().WillReturnResult(NewResult(1,1))
+	for i := 0; i < 3; i++ {
+		ep.ExpectExec().WillReturnResult(NewResult(1, 1))
 	}
 	mock.ExpectCommit()
 	tx, _ := db.Begin()
@@ -902,8 +902,8 @@ func TestPrepareExec(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer stmt.Close()
-	for i:=0; i < 3; i++ {
-		_, err := stmt.Exec(i, "Hello" + strconv.Itoa(i))
+	for i := 0; i < 3; i++ {
+		_, err := stmt.Exec(i, "Hello"+strconv.Itoa(i))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -938,8 +938,8 @@ func TestPrepareQuery(t *testing.T) {
 	}
 	defer rows.Close()
 	for rows.Next() {
-		var(
-			id int
+		var (
+			id     int
 			status string
 		)
 		if rows.Scan(&id, &status); id != 101 || status != "Hello" {

--- a/util.go
+++ b/util.go
@@ -11,14 +11,3 @@ var re = regexp.MustCompile("\\s+")
 func stripQuery(q string) (s string) {
 	return strings.TrimSpace(re.ReplaceAllString(q, " "))
 }
-
-// mimicking how sql.DB build their queries
-func buildQuery(q string)string{
-	q = strings.TrimSpace(q)
-	lines := strings.Split(q,"\n")
-	var newQuery string
-	for _,l := range lines{
-		newQuery = newQuery +" " +strings.TrimSpace(l)
-	}
-	return strings.TrimSpace(newQuery)
-}


### PR DESCRIPTION
the function I made on my previous PR actually useless :laughing:  you already have better function which is stripQuery, I realized that when my query have more whitespaces inside it - e.g. `name<space><space><space>= 'John'`
I just apply it before assigning on sqlRegexStr.