### PR TITLE
Add checking not empty arguments

### DIFF
--- a/argument.go
+++ b/argument.go
@@ -1,6 +1,9 @@
 package sqlmock
 
-import "database/sql/driver"
+import (
+	"database/sql/driver"
+	"reflect"
+)
 
 // Argument interface allows to match
 // any argument in specific way when used with
@@ -21,4 +24,36 @@ type anyArgument struct{}
 
 func (a anyArgument) Match(_ driver.Value) bool {
 	return true
+}
+
+// NotEmptyArg will return an Argument which can
+// match any kind of non zero arguments.
+//
+// Logic by type:
+// type     |answer | condition
+// -----------------------
+// int64     true    v != 0
+// float64   true    v != 0.0
+// bool      true    any values
+// []byte    true    len(v) != 0
+// string    true    v != ""
+// time.Time true    non zero value
+// nil       false
+func NotEmptyArg() Argument {
+	return notEmptyArgument{}
+}
+
+type notEmptyArgument struct{}
+
+func (a notEmptyArgument) Match(v driver.Value) bool {
+	if v == nil {
+		return false
+	}
+
+	switch v.(type) {
+	case bool:
+		return true
+	default:
+		return v != reflect.Zero(reflect.TypeOf(v)).Interface()
+	}
 }

--- a/argument_test.go
+++ b/argument_test.go
@@ -56,3 +56,43 @@ func TestByteSliceArgument(t *testing.T) {
 		t.Errorf("there were unfulfilled expections: %s", err)
 	}
 }
+
+func TestNotEmptyArgument(t *testing.T) {
+	t.Parallel()
+	db, mock, err := New()
+	if err != nil {
+		t.Errorf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer db.Close()
+
+	mock.ExpectExec("INSERT INTO users").
+		WithArgs(NotEmptyArg(), NotEmptyArg()).
+		WillReturnResult(NewResult(1, 1))
+
+	_, err = db.Exec("INSERT INTO users(name, created_at) VALUES (?, ?)", "yegor", time.Now())
+	if err != nil {
+		t.Errorf("error '%s' was not expected, while inserting a row", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("there were unfulfilled expections: %s", err)
+	}
+}
+
+func TestEmptyArgument(t *testing.T) {
+	t.Parallel()
+	db, mock, err := New()
+	if err != nil {
+		t.Errorf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer db.Close()
+
+	mock.ExpectExec("INSERT INTO users").
+		WithArgs(NotEmptyArg()).
+		WillReturnResult(NewResult(1, 1))
+
+	_, err = db.Exec("INSERT INTO users(name) VALUES (?)", "")
+	if err == nil {
+		t.Errorf("expected empty value error")
+	}
+}


### PR DESCRIPTION
AnyArg() does not help if expected value should not be empty