### PR TITLE
Change wording of error message for unset query return value

### DIFF
--- a/sqlmock.go
+++ b/sqlmock.go
@@ -287,7 +287,7 @@ func (c *sqlmock) exec(query string, args []namedValue) (*ExpectedExec, error) {
 	}
 
 	if expected.result == nil {
-		return nil, fmt.Errorf("ExecQuery '%s' with args %+v, must return a database/sql/driver.Result, but it was not set for expectation %T as %+v", query, args, expected, expected)
+		return nil, fmt.Errorf("No required return value of type database/sql/driver.Result was set for expectation %T as %+v", expected, expected)
 	}
 
 	return expected, nil
@@ -446,7 +446,7 @@ func (c *sqlmock) query(query string, args []namedValue) (*ExpectedQuery, error)
 	}
 
 	if expected.rows == nil {
-		return nil, fmt.Errorf("Query '%s' with args %+v, must return a database/sql/driver.Rows, but it was not set for expectation %T as %+v", query, args, expected, expected)
+		return nil, fmt.Errorf("No required return value of type database/sql/driver.Rows was set for expectation %T as %+v", expected, expected)
 	}
 	return expected, nil
 }


### PR DESCRIPTION
I forgot to call `.WillReturnRows(...)` on my `ExpectQuery` statement, which gave me the following error message:
```
Query 'INSERT INTO "Message" (.+) VALUES ($1, $2, $3),($4, $5, $6);$' with args [{Name: Ordinal:1 Value:1}], must return a database/sql/driver.Rows, but it was not set for expectation *sqlmock.ExpectedQuery as ExpectedQuery => expecting Query, QueryContext or QueryRow which:
  - matches sql: 'INSERT .+'
  - is with arguments:
    0 - 1
```
This lead me to believe there was something wrong with the query regex, or the arguments. I changed the wording so the message would read:
```
No required return value of type database/sql/driver.Rows was set for expectation *sqlmock.ExpectedQuery as ExpectedQuery => expecting Query, QueryContext or QueryRow which:
  - matches sql: 'INSERT .+'
  - is with arguments:
    0 - 1
```

I removed the query that was sent to sqlmock from the error message since it has nothing to do with the failure.