### PR TITLE
testsuite: fixes in NullInt/NullTime

### DIFF
--- a/stubs_test.go
+++ b/stubs_test.go
@@ -2,6 +2,7 @@ package sqlmock
 
 import (
 	"database/sql/driver"
+	"errors"
 	"fmt"
 	"strconv"
 	"time"
@@ -25,8 +26,28 @@ func (ni *NullInt) Scan(value interface{}) (err error) {
 	}
 
 	switch v := value.(type) {
-	case int, int8, int16, int32, int64:
-		ni.Integer, ni.Valid = v.(int), true
+	case int:
+		ni.Integer, ni.Valid = v, true
+		return
+	case int8:
+		ni.Integer, ni.Valid = int(v), true
+		return
+	case int16:
+		ni.Integer, ni.Valid = int(v), true
+		return
+	case int32:
+		ni.Integer, ni.Valid = int(v), true
+		return
+	case int64:
+		const maxUint = ^uint(0)
+		const minUint = 0
+		const maxInt = int(maxUint >> 1)
+		const minInt = -maxInt - 1
+
+		if v > int64(maxInt) || v < int64(minInt) {
+			return errors.New("value out of int range")
+		}
+		ni.Integer, ni.Valid = int(v), true
 		return
 	case []byte:
 		ni.Integer, err = strconv.Atoi(string(v))

--- a/stubs_test.go
+++ b/stubs_test.go
@@ -19,25 +19,18 @@ type NullInt struct {
 }
 
 // Satisfy sql.Scanner interface
-func (ni *NullInt) Scan(value interface{}) (err error) {
-	if value == nil {
-		ni.Integer, ni.Valid = 0, false
-		return
-	}
-
+func (ni *NullInt) Scan(value interface{}) error {
 	switch v := value.(type) {
+	case nil:
+		ni.Integer, ni.Valid = 0, false
 	case int:
 		ni.Integer, ni.Valid = v, true
-		return
 	case int8:
 		ni.Integer, ni.Valid = int(v), true
-		return
 	case int16:
 		ni.Integer, ni.Valid = int(v), true
-		return
 	case int32:
 		ni.Integer, ni.Valid = int(v), true
-		return
 	case int64:
 		const maxUint = ^uint(0)
 		const minUint = 0
@@ -48,25 +41,23 @@ func (ni *NullInt) Scan(value interface{}) (err error) {
 			return errors.New("value out of int range")
 		}
 		ni.Integer, ni.Valid = int(v), true
-		return
 	case []byte:
 		n, err := strconv.Atoi(string(v))
 		if err != nil {
 			return err
 		}
 		ni.Integer, ni.Valid = n, true
-		return nil
 	case string:
 		n, err := strconv.Atoi(v)
 		if err != nil {
 			return err
 		}
 		ni.Integer, ni.Valid = n, true
-		return nil
+	default:
+		ni.Valid = false
+		return fmt.Errorf("Can't convert %T to integer", value)
 	}
-
-	ni.Valid = false
-	return fmt.Errorf("Can't convert %T to integer", value)
+	return nil
 }
 
 // Satisfy sql.Valuer interface.
@@ -78,20 +69,17 @@ func (ni NullInt) Value() (driver.Value, error) {
 }
 
 // Satisfy sql.Scanner interface
-func (nt *NullTime) Scan(value interface{}) (err error) {
-	if value == nil {
-		nt.Time, nt.Valid = time.Time{}, false
-		return
-	}
-
+func (nt *NullTime) Scan(value interface{}) error {
 	switch v := value.(type) {
+	case nil:
+		nt.Time, nt.Valid = time.Time{}, false
 	case time.Time:
 		nt.Time, nt.Valid = v, true
-		return
+	default:
+		nt.Valid = false
+		return fmt.Errorf("Can't convert %T to time.Time", value)
 	}
-
-	nt.Valid = false
-	return fmt.Errorf("Can't convert %T to time.Time", value)
+	return nil
 }
 
 // Satisfy sql.Valuer interface.

--- a/stubs_test.go
+++ b/stubs_test.go
@@ -23,6 +23,11 @@ func (ni *NullInt) Scan(value interface{}) error {
 	switch v := value.(type) {
 	case nil:
 		ni.Integer, ni.Valid = 0, false
+
+	// FIXME int, int8, int16, int32 types are handled here but that should not
+	// be necessary: only int64 is a driver.Value
+	// Unfortunately, the sqlmock testsuite currently relies on that because
+	// sqlmock doesn't properly limits itself internally to pure driver.Value.
 	case int:
 		ni.Integer, ni.Valid = v, true
 	case int8:
@@ -31,6 +36,7 @@ func (ni *NullInt) Scan(value interface{}) error {
 		ni.Integer, ni.Valid = int(v), true
 	case int32:
 		ni.Integer, ni.Valid = int(v), true
+
 	case int64:
 		const maxUint = ^uint(0)
 		const minUint = 0

--- a/stubs_test.go
+++ b/stubs_test.go
@@ -74,7 +74,7 @@ func (ni NullInt) Value() (driver.Value, error) {
 	if !ni.Valid {
 		return nil, nil
 	}
-	return ni.Integer, nil
+	return int64(ni.Integer), nil
 }
 
 // Satisfy sql.Scanner interface

--- a/stubs_test.go
+++ b/stubs_test.go
@@ -54,8 +54,7 @@ func (ni *NullInt) Scan(value interface{}) error {
 		}
 		ni.Integer, ni.Valid = n, true
 	default:
-		ni.Valid = false
-		return fmt.Errorf("Can't convert %T to integer", value)
+		return fmt.Errorf("can't convert %T to integer", value)
 	}
 	return nil
 }
@@ -76,8 +75,7 @@ func (nt *NullTime) Scan(value interface{}) error {
 	case time.Time:
 		nt.Time, nt.Valid = v, true
 	default:
-		nt.Valid = false
-		return fmt.Errorf("Can't convert %T to time.Time", value)
+		return fmt.Errorf("can't convert %T to time.Time", value)
 	}
 	return nil
 }

--- a/stubs_test.go
+++ b/stubs_test.go
@@ -50,13 +50,19 @@ func (ni *NullInt) Scan(value interface{}) (err error) {
 		ni.Integer, ni.Valid = int(v), true
 		return
 	case []byte:
-		ni.Integer, err = strconv.Atoi(string(v))
-		ni.Valid = (err == nil)
-		return
+		n, err := strconv.Atoi(string(v))
+		if err != nil {
+			return err
+		}
+		ni.Integer, ni.Valid = n, true
+		return nil
 	case string:
-		ni.Integer, err = strconv.Atoi(v)
-		ni.Valid = (err == nil)
-		return
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			return err
+		}
+		ni.Integer, ni.Valid = n, true
+		return nil
 	}
 
 	ni.Valid = false


### PR DESCRIPTION
Fixes in types NullInt/NullTime defined and used only in the testsuite.

NullInt.Scan had a bug (panic) when handling `int64` and is now fixed.
In following commits I fixed other minor things in NullInt and NullTime and refactored to reduce lines of code.

Finally, I added a `FIXME` to remove handling of `int`/`int8`/`int16`/`int32` in the future because it should not be necessary (but it is in practice, because sqlmock does not properly handles integer values as pure `int64` internally and the testsuite relies on that behavior).