### PR TITLE
Use gopkg.in import path for Travis and examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ go:
   - 1.10.x
   # - tip # sadly fails most of the times
 
+sudo: false
+
 script:
   - go vet
   - test -z "$(go fmt ./...)" # fail if not formatted properly

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: go
 
+go_import_path: gopkg.in/DATA-DOG/go-sqlmock.v1
+
 go:
   - 1.2.x
   - 1.3.x

--- a/examples/basic/basic_test.go
+++ b/examples/basic/basic_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/DATA-DOG/go-sqlmock"
+	"gopkg.in/DATA-DOG/go-sqlmock.v1"
 )
 
 // a successful case

--- a/examples/blog/blog_test.go
+++ b/examples/blog/blog_test.go
@@ -8,7 +8,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/DATA-DOG/go-sqlmock"
+	"gopkg.in/DATA-DOG/go-sqlmock.v1"
 )
 
 func (a *api) assertJSON(actual []byte, data interface{}, t *testing.T) {

--- a/examples/orders/orders_test.go
+++ b/examples/orders/orders_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/DATA-DOG/go-sqlmock"
+	"gopkg.in/DATA-DOG/go-sqlmock.v1"
 )
 
 // will test that order with a different status, cannot be cancelled


### PR DESCRIPTION
In examples, switch to use the `gopkg.in/DATA-DOG/go-sqlmock.v1` import path.

In .travis.yml, tell Travis-CI to checkout the repo under `$GOPATH/src/gopkg.in/DATA-DOG/go-sqlmock.v1`. This allows examples to run using the proper code. This also allows any external contributors to be able to run Travis-CI on their fork with that fixed import path (very important !!!).

Also in .travis.yml, set `sudo: false` as we don't need `sudo`.