### PR TITLE
Apply parameter converter on row values

### DIFF
--- a/rows.go
+++ b/rows.go
@@ -126,6 +126,17 @@ func (r *Rows) AddRow(values ...driver.Value) *Rows {
 
 	row := make([]driver.Value, len(r.cols))
 	for i, v := range values {
+		// Convert user-friendly values (such as int or driver.Valuer)
+		// to database/sql native value (driver.Value such as int64)
+		var err error
+		v, err = driver.DefaultParameterConverter.ConvertValue(v)
+		if err != nil {
+			panic(fmt.Errorf(
+				"row #%d, column #%d (%q) type %T: %s",
+				len(r.rows)+1, i, r.cols[i], values[i], err,
+			))
+		}
+
 		row[i] = v
 	}
 

--- a/stubs_test.go
+++ b/stubs_test.go
@@ -23,20 +23,6 @@ func (ni *NullInt) Scan(value interface{}) error {
 	switch v := value.(type) {
 	case nil:
 		ni.Integer, ni.Valid = 0, false
-
-	// FIXME int, int8, int16, int32 types are handled here but that should not
-	// be necessary: only int64 is a driver.Value
-	// Unfortunately, the sqlmock testsuite currently relies on that because
-	// sqlmock doesn't properly limits itself internally to pure driver.Value.
-	case int:
-		ni.Integer, ni.Valid = v, true
-	case int8:
-		ni.Integer, ni.Valid = int(v), true
-	case int16:
-		ni.Integer, ni.Valid = int(v), true
-	case int32:
-		ni.Integer, ni.Valid = int(v), true
-
 	case int64:
 		const maxUint = ^uint(0)
 		const minUint = 0


### PR DESCRIPTION
Apply `driver.DefaultParameterConverter.ConvertValue` on input values when building a row. With this fix we now use pure `driver.Value` internally.

This is the fix [I teased in #127](https://github.com/DATA-DOG/go-sqlmock/pull/127#issuecomment-404494587).