### PR TITLE
Travis-CI: also run tests from examples directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ sudo: false
 script:
   - go vet
   - test -z "$(go fmt ./...)" # fail if not formatted properly
-  - go test -race -coverprofile=coverage.txt -covermode=atomic
+  - go test -race -coverprofile=coverage.txt -covermode=atomic ./...
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,8 @@ sudo: false
 script:
   - go vet
   - test -z "$(go fmt ./...)" # fail if not formatted properly
-  - go test -race -coverprofile=coverage.txt -covermode=atomic ./...
+  # "./..." is only supported from go1.10+
+  - go test -race -coverprofile=coverage.txt -covermode=atomic . $(find ./examples/* -type d)
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
On Travis, the examples (in sub directory `examples`) are not tested. This is the fix.