### PR TITLE
Allow to use a custom converter

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -35,8 +35,9 @@ func (d *mockDriver) Open(dsn string) (driver.Conn, error) {
 	return c, nil
 }
 
-// New creates sqlmock database connection
-// and a mock to manage expectations.
+// New creates sqlmock database connection and a mock to manage expectations.
+// Accepts options, like ValueConverterOption, to use a ValueConverter from
+// a specific driver.
 // Pings db so that all expectations could be
 // asserted.
 func New(options ...func(*sqlmock) error) (*sql.DB, Sqlmock, error) {
@@ -51,8 +52,10 @@ func New(options ...func(*sqlmock) error) (*sql.DB, Sqlmock, error) {
 	return smock.open(options)
 }
 
-// NewWithDSN creates sqlmock database connection
-// with a specific DSN and a mock to manage expectations.
+// NewWithDSN creates sqlmock database connection with a specific DSN
+// and a mock to manage expectations.
+// Accepts options, like ValueConverterOption, to use a ValueConverter from
+// a specific driver.
 // Pings db so that all expectations could be asserted.
 //
 // This method is introduced because of sql abstraction
@@ -75,13 +78,4 @@ func NewWithDSN(dsn string, options ...func(*sqlmock) error) (*sql.DB, Sqlmock, 
 	pool.Unlock()
 
 	return smock.open(options)
-}
-
-// WithValueConverter allows to create a sqlmock connection
-// with a custom ValueConverter to support drivers with special data types.
-func WithValueConverter(converter driver.ValueConverter) func(*sqlmock) error {
-	return func(s *sqlmock) error {
-		s.converter = converter
-		return nil
-	}
 }

--- a/driver_test.go
+++ b/driver_test.go
@@ -100,7 +100,7 @@ func TestTwoOpenConnectionsOnTheSameDSN(t *testing.T) {
 
 func TestWithOptions(t *testing.T) {
 	c := &converter{}
-	_, mock, err := New(WithValueConverter(c))
+	_, mock, err := New(ValueConverterOption(c))
 	if err != nil {
 		t.Errorf("expected no error, but got: %s", err)
 	}

--- a/driver_test.go
+++ b/driver_test.go
@@ -1,6 +1,8 @@
 package sqlmock
 
 import (
+	"database/sql/driver"
+	"errors"
 	"fmt"
 	"testing"
 )
@@ -8,6 +10,12 @@ import (
 type void struct{}
 
 func (void) Print(...interface{}) {}
+
+type converter struct{}
+
+func (c *converter) ConvertValue(v interface{}) (driver.Value, error) {
+	return nil, errors.New("converter disabled")
+}
 
 func ExampleNew() {
 	db, mock, err := New()
@@ -87,6 +95,18 @@ func TestTwoOpenConnectionsOnTheSameDSN(t *testing.T) {
 	}
 	if mock == mock2 {
 		t.Errorf("expected not the same mock instance, but it is the same")
+	}
+}
+
+func TestWithOptions(t *testing.T) {
+	c := &converter{}
+	_, mock, err := New(WithValueConverter(c))
+	if err != nil {
+		t.Errorf("expected no error, but got: %s", err)
+	}
+	smock, _ := mock.(*sqlmock)
+	if smock.converter.(*converter) != c {
+		t.Errorf("expected a custom converter to be set")
 	}
 }
 

--- a/expectations.go
+++ b/expectations.go
@@ -292,6 +292,7 @@ func (e *ExpectedPrepare) WillBeClosed() *ExpectedPrepare {
 func (e *ExpectedPrepare) ExpectQuery() *ExpectedQuery {
 	eq := &ExpectedQuery{}
 	eq.sqlRegex = e.sqlRegex
+	eq.converter = e.mock.converter
 	e.mock.expected = append(e.mock.expected, eq)
 	return eq
 }
@@ -301,6 +302,7 @@ func (e *ExpectedPrepare) ExpectQuery() *ExpectedQuery {
 func (e *ExpectedPrepare) ExpectExec() *ExpectedExec {
 	eq := &ExpectedExec{}
 	eq.sqlRegex = e.sqlRegex
+	eq.converter = e.mock.converter
 	e.mock.expected = append(e.mock.expected, eq)
 	return eq
 }
@@ -325,8 +327,9 @@ func (e *ExpectedPrepare) String() string {
 // adds a query matching logic
 type queryBasedExpectation struct {
 	commonExpectation
-	sqlRegex *regexp.Regexp
-	args     []driver.Value
+	sqlRegex  *regexp.Regexp
+	converter driver.ValueConverter
+	args      []driver.Value
 }
 
 func (e *queryBasedExpectation) attemptMatch(sql string, args []namedValue) (err error) {

--- a/expectations_before_go18.go
+++ b/expectations_before_go18.go
@@ -35,7 +35,7 @@ func (e *queryBasedExpectation) argsMatches(args []namedValue) error {
 
 		dval := e.args[k]
 		// convert to driver converter
-		darg, err := driver.DefaultParameterConverter.ConvertValue(dval)
+		darg, err := e.converter.ConvertValue(dval)
 		if err != nil {
 			return fmt.Errorf("could not convert %d argument %T - %+v to driver value: %s", k, e.args[k], e.args[k], err)
 		}

--- a/expectations_go18.go
+++ b/expectations_go18.go
@@ -49,7 +49,7 @@ func (e *queryBasedExpectation) argsMatches(args []namedValue) error {
 		}
 
 		// convert to driver converter
-		darg, err := driver.DefaultParameterConverter.ConvertValue(dval)
+		darg, err := e.converter.ConvertValue(dval)
 		if err != nil {
 			return fmt.Errorf("could not convert %d argument %T - %+v to driver value: %s", k, e.args[k], e.args[k], err)
 		}

--- a/expectations_go18_test.go
+++ b/expectations_go18_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestQueryExpectationNamedArgComparison(t *testing.T) {
-	e := &queryBasedExpectation{}
+	e := &queryBasedExpectation{converter: driver.DefaultParameterConverter}
 	against := []namedValue{{Value: int64(5), Name: "id"}}
 	if err := e.argsMatches(against); err != nil {
 		t.Errorf("arguments should match, since the no expectation was set, but got err: %s", err)

--- a/expectations_test.go
+++ b/expectations_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestQueryExpectationArgComparison(t *testing.T) {
-	e := &queryBasedExpectation{}
+	e := &queryBasedExpectation{converter: driver.DefaultParameterConverter}
 	against := []namedValue{{Value: int64(5), Ordinal: 1}}
 	if err := e.argsMatches(against); err != nil {
 		t.Errorf("arguments should match, since the no expectation was set, but got err: %s", err)
@@ -67,7 +67,7 @@ func TestQueryExpectationArgComparison(t *testing.T) {
 func TestQueryExpectationArgComparisonBool(t *testing.T) {
 	var e *queryBasedExpectation
 
-	e = &queryBasedExpectation{args: []driver.Value{true}}
+	e = &queryBasedExpectation{args: []driver.Value{true}, converter: driver.DefaultParameterConverter}
 	against := []namedValue{
 		{Value: true, Ordinal: 1},
 	}
@@ -75,7 +75,7 @@ func TestQueryExpectationArgComparisonBool(t *testing.T) {
 		t.Error("arguments should match, since arguments are the same")
 	}
 
-	e = &queryBasedExpectation{args: []driver.Value{false}}
+	e = &queryBasedExpectation{args: []driver.Value{false}, converter: driver.DefaultParameterConverter}
 	against = []namedValue{
 		{Value: false, Ordinal: 1},
 	}
@@ -83,7 +83,7 @@ func TestQueryExpectationArgComparisonBool(t *testing.T) {
 		t.Error("arguments should match, since argument are the same")
 	}
 
-	e = &queryBasedExpectation{args: []driver.Value{true}}
+	e = &queryBasedExpectation{args: []driver.Value{true}, converter: driver.DefaultParameterConverter}
 	against = []namedValue{
 		{Value: false, Ordinal: 1},
 	}
@@ -91,7 +91,7 @@ func TestQueryExpectationArgComparisonBool(t *testing.T) {
 		t.Error("arguments should not match, since argument is different")
 	}
 
-	e = &queryBasedExpectation{args: []driver.Value{false}}
+	e = &queryBasedExpectation{args: []driver.Value{false}, converter: driver.DefaultParameterConverter}
 	against = []namedValue{
 		{Value: true, Ordinal: 1},
 	}

--- a/options.go
+++ b/options.go
@@ -1,0 +1,12 @@
+package sqlmock
+
+import "database/sql/driver"
+
+// ValueConverterOption allows to create a sqlmock connection
+// with a custom ValueConverter to support drivers with special data types.
+func ValueConverterOption(converter driver.ValueConverter) func(*sqlmock) error {
+	return func(s *sqlmock) error {
+		s.converter = converter
+		return nil
+	}
+}

--- a/sqlmock.go
+++ b/sqlmock.go
@@ -180,6 +180,7 @@ func (c *sqlmock) ExpectationsWereMet() error {
 	return nil
 }
 
+// CheckNamedValue meets https://golang.org/pkg/database/sql/driver/#NamedValueChecker
 func (c *sqlmock) CheckNamedValue(nv *driver.NamedValue) (err error) {
 	nv.Value, err = c.converter.ConvertValue(nv.Value)
 	return err

--- a/sqlmock.go
+++ b/sqlmock.go
@@ -180,12 +180,6 @@ func (c *sqlmock) ExpectationsWereMet() error {
 	return nil
 }
 
-// CheckNamedValue meets https://golang.org/pkg/database/sql/driver/#NamedValueChecker
-func (c *sqlmock) CheckNamedValue(nv *driver.NamedValue) (err error) {
-	nv.Value, err = c.converter.ConvertValue(nv.Value)
-	return err
-}
-
 // Begin meets http://golang.org/pkg/database/sql/driver/#Conn interface
 func (c *sqlmock) Begin() (driver.Tx, error) {
 	ex, err := c.begin()

--- a/sqlmock_go18.go
+++ b/sqlmock_go18.go
@@ -111,3 +111,9 @@ func (stmt *statement) QueryContext(ctx context.Context, args []driver.NamedValu
 }
 
 // @TODO maybe add ExpectedBegin.WithOptions(driver.TxOptions)
+
+// CheckNamedValue meets https://golang.org/pkg/database/sql/driver/#NamedValueChecker
+func (c *sqlmock) CheckNamedValue(nv *driver.NamedValue) (err error) {
+	nv.Value, err = c.converter.ConvertValue(nv.Value)
+	return err
+}

--- a/sqlmock_test.go
+++ b/sqlmock_test.go
@@ -849,6 +849,32 @@ func TestRollbackThrow(t *testing.T) {
 	// Output:
 }
 
+func TestUnexpectedBegin(t *testing.T) {
+	// Open new mock database
+	db, _, err := New()
+	if err != nil {
+		fmt.Println("error creating mock database")
+		return
+	}
+	if _, err := db.Begin(); err == nil {
+		t.Error("an error was expected when calling begin, but got none")
+	}
+}
+
+func TestUnexpectedExec(t *testing.T) {
+	// Open new mock database
+	db, mock, err := New()
+	if err != nil {
+		fmt.Println("error creating mock database")
+		return
+	}
+	mock.ExpectBegin()
+	db.Begin()
+	if _, err := db.Exec("SELECT 1"); err == nil {
+		t.Error("an error was expected when calling exec, but got none")
+	}
+}
+
 func TestUnexpectedCommit(t *testing.T) {
 	// Open new mock database
 	db, mock, err := New()

--- a/sqlmock_test.go
+++ b/sqlmock_test.go
@@ -1113,3 +1113,31 @@ func TestExecExpectationErrorDelay(t *testing.T) {
 		t.Errorf("expecting a delay of less than %v before error, actual delay was %v", delay, elapsed)
 	}
 }
+
+func TestOptionsFail(t *testing.T) {
+	t.Parallel()
+	expected := errors.New("failing option")
+	option := func(*sqlmock) error {
+		return expected
+	}
+	db, _, err := New(option)
+	defer db.Close()
+	if err == nil {
+		t.Errorf("missing expecting error '%s' when opening a stub database connection", expected)
+	}
+}
+
+func TestNewRows(t *testing.T) {
+	t.Parallel()
+	db, mock, err := New()
+	if err != nil {
+		t.Errorf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer db.Close()
+	columns := []string{"col1", "col2"}
+
+	r := mock.NewRows(columns)
+	if len(r.cols) != len(columns) || r.cols[0] != columns[0] || r.cols[1] != columns[1] {
+		t.Errorf("expecting to create a row with columns %v, actual colmns are %v", r.cols, columns)
+	}
+}


### PR DESCRIPTION
Allow to use a custom converter if mocking a driver that supports some advanced data types like `[]string` in [kshvakov/clickhouse](https://github.com/kshvakov/clickhouse/).

Changes:
* added [functional options](https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis) to sqlmock.New and sqlmock.NewWithDSN to allow setting the converter property of sqlmock
* if no converter is specified, driver.DefaultParameterConverter is still used
* added `CheckNamedValue()` so connection implements [NamedValueChecker](https://golang.org/pkg/database/sql/driver/#NamedValueChecker)
* pass down custom converter to expectations
* added Sqlmock.NewRow as a wrapper to create rows with same converter
* added a few unrelated tests to bump coverage