### PR TITLE
Fix scanning of sql.NullInt64 when row is created from CSV input

### DIFF
--- a/rows.go
+++ b/rows.go
@@ -11,7 +11,7 @@ import (
 // CSVColumnParser is a function which converts trimmed csv
 // column string to a []byte representation. currently
 // transforms NULL to nil
-var CSVColumnParser = func(s string) []byte {
+var CSVColumnParser = func(s string) driver.Value {
 	switch {
 	case strings.ToLower(s) == "null":
 		return nil


### PR DESCRIPTION
Re-opened on branch v2 as per l3pp4rd's suggestion, because this change is backwards incompatible.

Implements enhancement requested in issue #140