### PR TITLE
Changed code in the RowError function to work correctly with scan operation.

### DIFF
--- a/rows.go
+++ b/rows.go
@@ -116,9 +116,11 @@ func (r *Rows) CloseError(err error) *Rows {
 // RowError allows to set an error
 // which will be returned when a given
 // row number is read
-func (r *Rows) RowError(row int, err error) *Rows {
+// To mock the error during the scan operation
+// an error also returned along with the row pointer
+func (r *Rows) RowError(row int, err error) (*Rows, error) {
 	r.nextErr[row] = err
-	return r
+	return r, err
 }
 
 // AddRow composed from database driver.Value slice

--- a/rows_go18_test.go
+++ b/rows_go18_test.go
@@ -16,7 +16,7 @@ func TestQueryMultiRows(t *testing.T) {
 	defer db.Close()
 
 	rs1 := NewRows([]string{"id", "title"}).AddRow(5, "hello world")
-	rs2 := NewRows([]string{"name"}).AddRow("gopher").AddRow("john").AddRow("jane").RowError(2, fmt.Errorf("error"))
+	rs2,_ := NewRows([]string{"name"}).AddRow("gopher").AddRow("john").AddRow("jane").RowError(2, fmt.Errorf("error"))
 
 	mock.ExpectQuery("SELECT (.+) FROM articles WHERE id = \\?;SELECT name FROM users").
 		WithArgs(5).

--- a/rows_test.go
+++ b/rows_test.go
@@ -43,7 +43,7 @@ func ExampleRows_rowError() {
 	}
 	defer db.Close()
 
-	rows := NewRows([]string{"id", "title"}).
+	rows, _ := NewRows([]string{"id", "title"}).
 		AddRow(0, "one").
 		AddRow(1, "two").
 		RowError(1, fmt.Errorf("row error"))
@@ -128,7 +128,7 @@ func TestAllowsToSetRowsErrors(t *testing.T) {
 	}
 	defer db.Close()
 
-	rows := NewRows([]string{"id", "title"}).
+	rows, _ := NewRows([]string{"id", "title"}).
 		AddRow(0, "one").
 		AddRow(1, "two").
 		RowError(1, fmt.Errorf("error"))


### PR DESCRIPTION
Now it returns the particular error and the pointer to the rows.
Modified tests based on the change in the code.
All working correctly without any error.
Tests passed successfully.