### PR TITLE
Add support for repeatable assertions.

### DIFF
--- a/rows.go
+++ b/rows.go
@@ -78,6 +78,13 @@ func (rs *rowSets) empty() bool {
 	return true
 }
 
+func (rs *rowSets) reset() {
+	for _, r := range rs.sets {
+		r.pos = 0
+	}
+	rs.pos = 0
+}
+
 // Rows is a mocked collection of rows to
 // return for Query result
 type Rows struct {

--- a/sqlmock.go
+++ b/sqlmock.go
@@ -135,10 +135,21 @@ func (c *sqlmock) Close() error {
 	var ok bool
 	for _, next := range c.expected {
 		next.Lock()
-		if next.fulfilled() {
+		if !next.canMatch() {
 			next.Unlock()
 			fulfilled++
 			continue
+		}
+
+		// Check if this is a repeatable exectation that we might be done with.
+		if next.isRepeatable() && next.fulfilled() {
+			// Repeatable and activated at least once. If it doesn't match, just keep going.
+			_, ok := next.(*ExpectedClose)
+			if c.ordered && !ok {
+				next.Unlock()
+				fulfilled++
+				continue
+			}
 		}
 
 		if expected, ok = next.(*ExpectedClose); ok {
@@ -199,10 +210,21 @@ func (c *sqlmock) begin() (*ExpectedBegin, error) {
 	var fulfilled int
 	for _, next := range c.expected {
 		next.Lock()
-		if next.fulfilled() {
+		if !next.canMatch() {
 			next.Unlock()
 			fulfilled++
 			continue
+		}
+
+		// Check if this is a repeatable exectation that we might be done with.
+		if next.isRepeatable() && next.fulfilled() {
+			// Repeatable and activated at least once. If it doesn't match, just keep going.
+			_, ok := next.(*ExpectedBegin)
+			if c.ordered && !ok {
+				next.Unlock()
+				fulfilled++
+				continue
+			}
 		}
 
 		if expected, ok = next.(*ExpectedBegin); ok {
@@ -262,10 +284,26 @@ func (c *sqlmock) exec(query string, args []namedValue) (*ExpectedExec, error) {
 	var ok bool
 	for _, next := range c.expected {
 		next.Lock()
-		if next.fulfilled() {
+		if !next.canMatch() {
 			next.Unlock()
 			fulfilled++
 			continue
+		}
+
+		// Check if this is a repeatable exectation that we might be done with.
+		if next.isRepeatable() && next.fulfilled() {
+			// Repeatable and activated at least once. If it doesn't match, just keep going.
+			exec, ok := next.(*ExpectedExec)
+			if c.ordered && !ok {
+				next.Unlock()
+				fulfilled++
+				continue
+			}
+			if exec.attemptMatch(query, args) != nil {
+				next.Unlock()
+				fulfilled++
+				continue
+			}
 		}
 
 		if c.ordered {
@@ -343,10 +381,26 @@ func (c *sqlmock) prepare(query string) (*ExpectedPrepare, error) {
 
 	for _, next := range c.expected {
 		next.Lock()
-		if next.fulfilled() {
+		if !next.canMatch() {
 			next.Unlock()
 			fulfilled++
 			continue
+		}
+
+		// Check if this is a repeatable exectation that we might be done with.
+		if next.isRepeatable() && next.fulfilled() {
+			// Repeatable and activated at least once. If it doesn't match, just keep going.
+			pr, ok := next.(*ExpectedPrepare)
+			if c.ordered && !ok {
+				next.Unlock()
+				fulfilled++
+				continue
+			}
+			if !pr.sqlRegex.MatchString(query) {
+				next.Unlock()
+				fulfilled++
+				continue
+			}
 		}
 
 		if c.ordered {
@@ -424,10 +478,26 @@ func (c *sqlmock) query(query string, args []namedValue) (*ExpectedQuery, error)
 	var ok bool
 	for _, next := range c.expected {
 		next.Lock()
-		if next.fulfilled() {
+		if !next.canMatch() {
 			next.Unlock()
 			fulfilled++
 			continue
+		}
+
+		// Check if this is a repeatable exectation that we might be done with.
+		if next.isRepeatable() && next.fulfilled() {
+			// Repeatable and activated at least once. If it doesn't match, just keep going.
+			qr, ok := next.(*ExpectedQuery)
+			if c.ordered && !ok {
+				next.Unlock()
+				fulfilled++
+				continue
+			}
+			if qr.attemptMatch(query, args) != nil {
+				next.Unlock()
+				fulfilled++
+				continue
+			}
 		}
 
 		if c.ordered {
@@ -503,10 +573,21 @@ func (c *sqlmock) Commit() error {
 	var ok bool
 	for _, next := range c.expected {
 		next.Lock()
-		if next.fulfilled() {
+		if !next.canMatch() {
 			next.Unlock()
 			fulfilled++
 			continue
+		}
+
+		// Check if this is a repeatable exectation that we might be done with.
+		if next.isRepeatable() && next.fulfilled() {
+			// Repeatable and activated at least once. If it doesn't match, just keep going.
+			_, ok := next.(*ExpectedCommit)
+			if c.ordered && !ok {
+				next.Unlock()
+				fulfilled++
+				continue
+			}
 		}
 
 		if expected, ok = next.(*ExpectedCommit); ok {
@@ -538,10 +619,21 @@ func (c *sqlmock) Rollback() error {
 	var ok bool
 	for _, next := range c.expected {
 		next.Lock()
-		if next.fulfilled() {
+		if !next.canMatch() {
 			next.Unlock()
 			fulfilled++
 			continue
+		}
+
+		// Check if this is a repeatable exectation that we might be done with.
+		if next.isRepeatable() && next.fulfilled() {
+			// Repeatable and activated at least once. If it doesn't match, just keep going.
+			_, ok := next.(*ExpectedRollback)
+			if c.ordered && !ok {
+				next.Unlock()
+				fulfilled++
+				continue
+			}
 		}
 
 		if expected, ok = next.(*ExpectedRollback); ok {

--- a/sqlmock.go
+++ b/sqlmock.go
@@ -542,6 +542,7 @@ func (c *sqlmock) query(query string, args []namedValue) (*ExpectedQuery, error)
 	if expected.rows == nil {
 		return nil, fmt.Errorf("Query '%s' with args %+v, must return a database/sql/driver.Rows, but it was not set for expectation %T as %+v", query, args, expected, expected)
 	}
+	expected.rows.(*rowSets).reset()
 	return expected, nil
 }
 


### PR DESCRIPTION
Implements #82.

The syntax looks like:

```go
	mock.ExpectQuery("SELECT (.+) FROM articles WHERE id = ?").
		WithArgs(5).
		WillReturnRows(rs).
		AnyNumberOfTimes()
```

My specific use case is testing some polling APIs that might run any number of times during the test based on exact timing, but this seemed like a generally useful thing to have :-)