### PR TITLE
Out parameter support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/DATA-DOG/go-sqlmock
+
+go 1.12

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,1 @@
 module github.com/DATA-DOG/go-sqlmock
-
-go 1.12

--- a/sqlmock_go18.go
+++ b/sqlmock_go18.go
@@ -113,4 +113,3 @@ func (stmt *statement) QueryContext(ctx context.Context, args []driver.NamedValu
 }
 
 // @TODO maybe add ExpectedBegin.WithOptions(driver.TxOptions)
-

--- a/sqlmock_go18.go
+++ b/sqlmock_go18.go
@@ -114,8 +114,3 @@ func (stmt *statement) QueryContext(ctx context.Context, args []driver.NamedValu
 
 // @TODO maybe add ExpectedBegin.WithOptions(driver.TxOptions)
 
-// CheckNamedValue meets https://golang.org/pkg/database/sql/driver/#NamedValueChecker
-func (c *sqlmock) CheckNamedValue(nv *driver.NamedValue) (err error) {
-	nv.Value, err = c.converter.ConvertValue(nv.Value)
-	return err
-}

--- a/sqlmock_go18_19.go
+++ b/sqlmock_go18_19.go
@@ -1,0 +1,11 @@
+// +build go1.8,!go1.9
+
+package sqlmock
+
+import "database/sql/driver"
+
+// CheckNamedValue meets https://golang.org/pkg/database/sql/driver/#NamedValueChecker
+func (c *sqlmock) CheckNamedValue(nv *driver.NamedValue) (err error) {
+	nv.Value, err = c.converter.ConvertValue(nv.Value)
+	return err
+}

--- a/sqlmock_go19.go
+++ b/sqlmock_go19.go
@@ -1,0 +1,19 @@
+// +build go1.9
+
+package sqlmock
+
+import (
+	"database/sql"
+	"database/sql/driver"
+)
+
+// CheckNamedValue meets https://golang.org/pkg/database/sql/driver/#NamedValueChecker
+func (c *sqlmock) CheckNamedValue(nv *driver.NamedValue) (err error) {
+	switch nv.Value.(type) {
+	case sql.Out:
+		return nil
+	default:
+		nv.Value, err = c.converter.ConvertValue(nv.Value)
+		return err
+	}
+}


### PR DESCRIPTION
This provides support for the usage of `sql.Out` parameters with the sqlmock driver.  While this partially addresses #144 , it should be noted that this isn't a _matcher_ for `sql.Out` values, and users will likely have to use a custom matcher or `AnyArg()` for now.