### PR TITLE
Invalidate memory scanned into sql.RawBytes

### DIFF
--- a/rows_go13_test.go
+++ b/rows_go13_test.go
@@ -1,0 +1,31 @@
+// +build go1.3
+
+package sqlmock
+
+import (
+	"database/sql"
+	"testing"
+)
+
+func TestQueryRowBytesNotInvalidatedByNext_stringIntoRawBytes(t *testing.T) {
+	t.Parallel()
+	rows := NewRows([]string{"raw"}).
+		AddRow(`one binary value with some text!`).
+		AddRow(`two binary value with even more text than the first one`)
+	scan := func(rs *sql.Rows) ([]byte, error) {
+		var raw sql.RawBytes
+		return raw, rs.Scan(&raw)
+	}
+	want := [][]byte{[]byte(`one binary value with some text!`), []byte(`two binary value with even more text than the first one`)}
+	queryRowBytesNotInvalidatedByNext(t, rows, scan, want)
+}
+
+func TestQueryRowBytesNotInvalidatedByClose_stringIntoRawBytes(t *testing.T) {
+	t.Parallel()
+	rows := NewRows([]string{"raw"}).AddRow(`one binary value with some text!`)
+	scan := func(rs *sql.Rows) ([]byte, error) {
+		var raw sql.RawBytes
+		return raw, rs.Scan(&raw)
+	}
+	queryRowBytesNotInvalidatedByClose(t, rows, scan, []byte(`one binary value with some text!`))
+}

--- a/rows_go18_test.go
+++ b/rows_go18_test.go
@@ -3,6 +3,8 @@
 package sqlmock
 
 import (
+	"database/sql"
+	"encoding/json"
 	"fmt"
 	"testing"
 )
@@ -89,4 +91,115 @@ func TestQueryMultiRows(t *testing.T) {
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("there were unfulfilled expectations: %s", err)
 	}
+}
+
+func TestQueryRowBytesInvalidatedByNext_jsonRawMessageIntoRawBytes(t *testing.T) {
+	t.Parallel()
+	replace := []byte(invalid)
+	rows := NewRows([]string{"raw"}).
+		AddRow(json.RawMessage(`{"thing": "one", "thing2": "two"}`)).
+		AddRow(json.RawMessage(`{"that": "foo", "this": "bar"}`))
+	scan := func(rs *sql.Rows) ([]byte, error) {
+		var raw sql.RawBytes
+		return raw, rs.Scan(&raw)
+	}
+	want := []struct {
+		Initial  []byte
+		Replaced []byte
+	}{
+		{Initial: []byte(`{"thing": "one", "thing2": "two"}`), Replaced: replace[:len(replace)-6]},
+		{Initial: []byte(`{"that": "foo", "this": "bar"}`), Replaced: replace[:len(replace)-9]},
+	}
+	queryRowBytesInvalidatedByNext(t, rows, scan, want)
+}
+
+func TestQueryRowBytesNotInvalidatedByNext_jsonRawMessageIntoBytes(t *testing.T) {
+	t.Parallel()
+	rows := NewRows([]string{"raw"}).
+		AddRow(json.RawMessage(`{"thing": "one", "thing2": "two"}`)).
+		AddRow(json.RawMessage(`{"that": "foo", "this": "bar"}`))
+	scan := func(rs *sql.Rows) ([]byte, error) {
+		var b []byte
+		return b, rs.Scan(&b)
+	}
+	want := [][]byte{[]byte(`{"thing": "one", "thing2": "two"}`), []byte(`{"that": "foo", "this": "bar"}`)}
+	queryRowBytesNotInvalidatedByNext(t, rows, scan, want)
+}
+
+func TestQueryRowBytesNotInvalidatedByNext_bytesIntoCustomBytes(t *testing.T) {
+	t.Parallel()
+	rows := NewRows([]string{"raw"}).
+		AddRow([]byte(`one binary value with some text!`)).
+		AddRow([]byte(`two binary value with even more text than the first one`))
+	scan := func(rs *sql.Rows) ([]byte, error) {
+		type customBytes []byte
+		var b customBytes
+		return b, rs.Scan(&b)
+	}
+	want := [][]byte{[]byte(`one binary value with some text!`), []byte(`two binary value with even more text than the first one`)}
+	queryRowBytesNotInvalidatedByNext(t, rows, scan, want)
+}
+
+func TestQueryRowBytesNotInvalidatedByNext_jsonRawMessageIntoCustomBytes(t *testing.T) {
+	t.Parallel()
+	rows := NewRows([]string{"raw"}).
+		AddRow(json.RawMessage(`{"thing": "one", "thing2": "two"}`)).
+		AddRow(json.RawMessage(`{"that": "foo", "this": "bar"}`))
+	scan := func(rs *sql.Rows) ([]byte, error) {
+		type customBytes []byte
+		var b customBytes
+		return b, rs.Scan(&b)
+	}
+	want := [][]byte{[]byte(`{"thing": "one", "thing2": "two"}`), []byte(`{"that": "foo", "this": "bar"}`)}
+	queryRowBytesNotInvalidatedByNext(t, rows, scan, want)
+}
+
+func TestQueryRowBytesNotInvalidatedByClose_bytesIntoCustomBytes(t *testing.T) {
+	t.Parallel()
+	rows := NewRows([]string{"raw"}).AddRow([]byte(`one binary value with some text!`))
+	scan := func(rs *sql.Rows) ([]byte, error) {
+		type customBytes []byte
+		var b customBytes
+		return b, rs.Scan(&b)
+	}
+	queryRowBytesNotInvalidatedByClose(t, rows, scan, []byte(`one binary value with some text!`))
+}
+
+func TestQueryRowBytesInvalidatedByClose_jsonRawMessageIntoRawBytes(t *testing.T) {
+	t.Parallel()
+	replace := []byte(invalid)
+	rows := NewRows([]string{"raw"}).AddRow(json.RawMessage(`{"thing": "one", "thing2": "two"}`))
+	scan := func(rs *sql.Rows) ([]byte, error) {
+		var raw sql.RawBytes
+		return raw, rs.Scan(&raw)
+	}
+	want := struct {
+		Initial  []byte
+		Replaced []byte
+	}{
+		Initial:  []byte(`{"thing": "one", "thing2": "two"}`),
+		Replaced: replace[:len(replace)-6],
+	}
+	queryRowBytesInvalidatedByClose(t, rows, scan, want)
+}
+
+func TestQueryRowBytesNotInvalidatedByClose_jsonRawMessageIntoBytes(t *testing.T) {
+	t.Parallel()
+	rows := NewRows([]string{"raw"}).AddRow(json.RawMessage(`{"thing": "one", "thing2": "two"}`))
+	scan := func(rs *sql.Rows) ([]byte, error) {
+		var b []byte
+		return b, rs.Scan(&b)
+	}
+	queryRowBytesNotInvalidatedByClose(t, rows, scan, []byte(`{"thing": "one", "thing2": "two"}`))
+}
+
+func TestQueryRowBytesNotInvalidatedByClose_jsonRawMessageIntoCustomBytes(t *testing.T) {
+	t.Parallel()
+	rows := NewRows([]string{"raw"}).AddRow(json.RawMessage(`{"thing": "one", "thing2": "two"}`))
+	scan := func(rs *sql.Rows) ([]byte, error) {
+		type customBytes []byte
+		var b customBytes
+		return b, rs.Scan(&b)
+	}
+	queryRowBytesNotInvalidatedByClose(t, rows, scan, []byte(`{"thing": "one", "thing2": "two"}`))
 }


### PR DESCRIPTION
The intention of sql.RawBytes is for it to hold memory owned by the database. When used, it's content is only valid until the `Next`, `Scan` or `Close` is called on the `Rows`

To ensure that we meet this behaviour, when `[]byte` is used in a column, it's value is copied to a buffer that we keep track of for later invalidation. By doing this, incorrect use of `sql.RawBytes` values is exposed in tests that use go-sqlmock. Without this, when a real database is used and it's driver does share memory, then those issues would not be exposed until runtime (and in non-obvious ways)