### PR TITLE
Implement ExpectPings to watch for Ping attempts on the database

### DIFF
--- a/expectations.go
+++ b/expectations.go
@@ -353,3 +353,32 @@ func (e *queryBasedExpectation) attemptArgMatch(args []namedValue) (err error) {
 	err = e.argsMatches(args)
 	return
 }
+
+// ExpectedPing is used to manage *sql.DB.Ping expectations.
+// Returned by *Sqlmock.ExpectPing.
+type ExpectedPing struct {
+	commonExpectation
+	delay time.Duration
+}
+
+// WillDelayFor allows to specify duration for which it will delay result. May
+// be used together with Context.
+func (e *ExpectedPing) WillDelayFor(duration time.Duration) *ExpectedPing {
+	e.delay = duration
+	return e
+}
+
+// WillReturnError allows to set an error for expected database ping
+func (e *ExpectedPing) WillReturnError(err error) *ExpectedPing {
+	e.err = err
+	return e
+}
+
+// String returns string representation
+func (e *ExpectedPing) String() string {
+	msg := "ExpectedPing => expecting database Ping"
+	if e.err != nil {
+		msg += fmt.Sprintf(", which should return error: %s", e.err)
+	}
+	return msg
+}

--- a/options.go
+++ b/options.go
@@ -20,3 +20,19 @@ func QueryMatcherOption(queryMatcher QueryMatcher) func(*sqlmock) error {
 		return nil
 	}
 }
+
+// MonitorPingsOption determines whether calls to Ping on the driver should be
+// observed and mocked.
+//
+// If true is passed, we will check these calls were expected. Expectations can
+// be registered using the ExpectPing() method on the mock.
+//
+// If false is passed or this option is omitted, calls to Ping will not be
+// considered when determining expectations and calls to ExpectPing will have
+// no effect.
+func MonitorPingsOption(monitorPings bool) func(*sqlmock) error {
+	return func(s *sqlmock) error {
+		s.monitorPings = monitorPings
+		return nil
+	}
+}

--- a/sqlmock_before_go18.go
+++ b/sqlmock_before_go18.go
@@ -1,0 +1,10 @@
+// +build !go1.8
+
+package sqlmock
+
+import "log"
+
+func (c *sqlmock) ExpectPing() *ExpectedPing {
+	log.Println("ExpectPing has no effect on Go 1.7 or below")
+	return &ExpectedPing{}
+}

--- a/sqlmock_before_go18_test.go
+++ b/sqlmock_before_go18_test.go
@@ -1,0 +1,26 @@
+// +build !go1.8
+
+package sqlmock
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestSqlmockExpectPingHasNoEffect(t *testing.T) {
+	db, mock, err := New()
+	if err != nil {
+		t.Errorf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer db.Close()
+
+	e := mock.ExpectPing()
+
+	// Methods on the expectation can be called
+	e.WillDelayFor(time.Hour).WillReturnError(fmt.Errorf("an error"))
+
+	if err = mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("expected no error to be returned, but got '%s'", err)
+	}
+}


### PR DESCRIPTION
Implemented an `ExpectPing` method to watch for calls to `Ping` on the driver.

Some complexity: `Ping` is used on open to drive internal sql library behaviour to open a connection. We don't want these pings to be treated as expectations so there's a mechanism to override this checking in some cases.

In order to neatly implement the behaviour without duplicating the `Sqlmock` interface, the `ExpectPing` method is installed in the mock in all Go versions, but does nothing in pre-1.8 instances.