### PR TITLE
Remove 1.12 minimum Go version from go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,1 @@
 module github.com/DATA-DOG/go-sqlmock
-
-go 1.12


### PR DESCRIPTION
Signed-off-by: Gábor Lipták <gliptak@gmail.com>

https://github.com/DATA-DOG/go-sqlmock/issues/214