### PR TITLE
Added jmoiron/sqlx support

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
+	"github.com/jmoiron/sqlx"
 	"sync"
 )
 
@@ -52,6 +53,23 @@ func New(options ...func(*sqlmock) error) (*sql.DB, Sqlmock, error) {
 	return smock.open(options)
 }
 
+// Newx creates sqlmock database connection of *sqlx.DB type and a mock to manage expectations.
+// Accepts options, like ValueConverterOption, to use a ValueConverter from
+// a specific driver.
+// Pings db so that all expectations could be
+// asserted.
+func Newx(options ...func(*sqlmock) error) (*sqlx.DB, Sqlmock, error) {
+	pool.Lock()
+	dsn := fmt.Sprintf("sqlmock_db_%d", pool.counter)
+	pool.counter++
+
+	smock := &sqlmock{dsn: dsn, drv: pool, ordered: true}
+	pool.conns[dsn] = smock
+	pool.Unlock()
+
+	return smock.openx(options)
+}
+
 // NewWithDSN creates sqlmock database connection with a specific DSN
 // and a mock to manage expectations.
 // Accepts options, like ValueConverterOption, to use a ValueConverter from
@@ -78,4 +96,32 @@ func NewWithDSN(dsn string, options ...func(*sqlmock) error) (*sql.DB, Sqlmock, 
 	pool.Unlock()
 
 	return smock.open(options)
+}
+
+// NewxWithDSN creates sqlmock database connection of *sqlx.DB type with a specific DSN
+// and a mock to manage expectations.
+// Accepts options, like ValueConverterOption, to use a ValueConverter from
+// a specific driver.
+// Pings db so that all expectations could be asserted.
+//
+// This method is introduced because of sql abstraction
+// libraries, which do not provide a way to initialize
+// with sql.DB instance. For example GORM library.
+//
+// Note, it will error if attempted to create with an
+// already used dsn
+//
+// It is not recommended to use this method, unless you
+// really need it and there is no other way around.
+func NewxWithDSN(dsn string, options ...func(*sqlmock) error) (*sqlx.DB, Sqlmock, error) {
+	pool.Lock()
+	if _, ok := pool.conns[dsn]; ok {
+		pool.Unlock()
+		return nil, nil, fmt.Errorf("cannot create a new mock database with the same dsn: %s", dsn)
+	}
+	smock := &sqlmock{dsn: dsn, drv: pool, ordered: true}
+	pool.conns[dsn] = smock
+	pool.Unlock()
+
+	return smock.openx(options)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,8 @@
 module github.com/DATA-DOG/go-sqlmock
+
+go 1.15
+
+require (
+	github.com/jmoiron/sqlx v1.2.0
+	github.com/kisielk/sqlstruct v0.0.0-20150923205031-648daed35d49
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,9 @@
+github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
+github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
+github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
+github.com/jmoiron/sqlx v1.2.0 h1:41Ip0zITnmWNR/vHV+S4m+VoUivnWY5E4OJfLZjCJMA=
+github.com/jmoiron/sqlx v1.2.0/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=
+github.com/kisielk/sqlstruct v0.0.0-20150923205031-648daed35d49 h1:o/c0aWEP/m6n61xlYW2QP4t9424qlJOsxugn5Zds2Rg=
+github.com/kisielk/sqlstruct v0.0.0-20150923205031-648daed35d49/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
+github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
+github.com/mattn/go-sqlite3 v1.9.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=


### PR DESCRIPTION
Implemented new functions `Newx()` and `NewxWithDSN()` that returnes `*sqlx.DB` from https://github.com/jmoiron/sqlx