### PR TITLE
update the way expectations.go initializes the margs variable

### DIFF
--- a/expectations.go
+++ b/expectations.go
@@ -222,7 +222,7 @@ func (e *ExpectedExec) String() string {
 		msg += "\n  - is without arguments"
 	} else {
 		msg += "\n  - is with arguments:\n"
-		var margs []string
+		margs := make([]string, 0, len(e.args))
 		for i, arg := range e.args {
 			margs = append(margs, fmt.Sprintf("    %d - %+v", i, arg))
 		}


### PR DESCRIPTION
Hi, This is a small change, but it will send a PR.
In the String function of expectations.go, there is a place where it initializes a variable called margs.
I thought this would be better for Go's slice specification, since the capacity of the slice to be appended can be allocated in advance by the length of the args.