### PR TITLE
set expectations to run multiple times

### DIFF
--- a/expectations.go
+++ b/expectations.go
@@ -120,16 +120,24 @@ func (e *ExpectedRollback) String() string {
 	return msg
 }
 
+type mockRows interface {
+	driver.Rows
+
+	WillBeClosed(closed bool)
+
+	AreClosed() bool
+
+	MustBeClosed() bool
+}
+
 // ExpectedQuery is used to manage *sql.DB.Query, *dql.DB.QueryRow, *sql.Tx.Query,
 // *sql.Tx.QueryRow, *sql.Stmt.Query or *sql.Stmt.QueryRow expectations.
 // Returned by *Sqlmock.ExpectQuery.
 type ExpectedQuery struct {
 	queryBasedExpectation
-	rows             driver.Rows
-	mockedRows       []*Rows
-	delay            time.Duration
-	rowsMustBeClosed bool
-	rowsWereClosed   bool
+	rows       mockRows
+	mockedRows []*Rows
+	delay      time.Duration
 }
 
 // WithArgs will match given expected args to actual database query arguments.
@@ -142,7 +150,7 @@ func (e *ExpectedQuery) WithArgs(args ...driver.Value) *ExpectedQuery {
 
 // RowsWillBeClosed expects this query rows to be closed.
 func (e *ExpectedQuery) RowsWillBeClosed() *ExpectedQuery {
-	e.rowsMustBeClosed = true
+	e.rows.WillBeClosed(true)
 	return e
 }
 

--- a/expectations.go
+++ b/expectations.go
@@ -20,12 +20,12 @@ type expectation interface {
 // satisfies the expectation interface
 type commonExpectation struct {
 	sync.Mutex
-	triggered bool
-	err       error
+	times int
+	err   error
 }
 
 func (e *commonExpectation) fulfilled() bool {
-	return e.triggered
+	return e.times == -1
 }
 
 // ExpectedClose is used to manage *sql.DB.Close expectation
@@ -126,6 +126,7 @@ func (e *ExpectedRollback) String() string {
 type ExpectedQuery struct {
 	queryBasedExpectation
 	rows             driver.Rows
+	mockedRows       []*Rows
 	delay            time.Duration
 	rowsMustBeClosed bool
 	rowsWereClosed   bool
@@ -155,6 +156,11 @@ func (e *ExpectedQuery) WillReturnError(err error) *ExpectedQuery {
 // result. May be used together with Context
 func (e *ExpectedQuery) WillDelayFor(duration time.Duration) *ExpectedQuery {
 	e.delay = duration
+	return e
+}
+
+func (e *ExpectedQuery) Times(times int) *ExpectedQuery {
+	e.times = times - 1
 	return e
 }
 
@@ -210,6 +216,11 @@ func (e *ExpectedExec) WillReturnError(err error) *ExpectedExec {
 // result. May be used together with Context
 func (e *ExpectedExec) WillDelayFor(duration time.Duration) *ExpectedExec {
 	e.delay = duration
+	return e
+}
+
+func (e *ExpectedExec) Times(times int) *ExpectedExec {
+	e.times = times - 1
 	return e
 }
 

--- a/expectations_go18.go
+++ b/expectations_go18.go
@@ -31,7 +31,9 @@ func (e *ExpectedQuery) WillReturnRows(rows ...*Rows) *ExpectedQuery {
 }
 
 func (e *ExpectedQuery) resetRows() {
+	closed := e.rows.MustBeClosed()
 	e = e.WillReturnRows(e.mockedRows...)
+	e.rows.WillBeClosed(closed)
 }
 
 func (e *queryBasedExpectation) argsMatches(args []driver.NamedValue) error {

--- a/expectations_go18.go
+++ b/expectations_go18.go
@@ -14,7 +14,9 @@ import (
 func (e *ExpectedQuery) WillReturnRows(rows ...*Rows) *ExpectedQuery {
 	defs := 0
 	sets := make([]*Rows, len(rows))
+	e.mockedRows = rows
 	for i, r := range rows {
+		r.pos = 0
 		sets[i] = r
 		if r.def != nil {
 			defs++
@@ -26,6 +28,10 @@ func (e *ExpectedQuery) WillReturnRows(rows ...*Rows) *ExpectedQuery {
 		e.rows = &rowSets{sets: sets, ex: e}
 	}
 	return e
+}
+
+func (e *ExpectedQuery) resetRows() {
+	e = e.WillReturnRows(e.mockedRows...)
 }
 
 func (e *queryBasedExpectation) argsMatches(args []driver.NamedValue) error {

--- a/rows.go
+++ b/rows.go
@@ -23,10 +23,12 @@ var CSVColumnParser = func(s string) []byte {
 }
 
 type rowSets struct {
-	sets []*Rows
-	pos  int
-	ex   *ExpectedQuery
-	raw  [][]byte
+	sets             []*Rows
+	pos              int
+	ex               *ExpectedQuery
+	raw              [][]byte
+	rowsMustBeClosed bool
+	rowsWereClosed   bool
 }
 
 func (rs *rowSets) Columns() []string {
@@ -35,7 +37,7 @@ func (rs *rowSets) Columns() []string {
 
 func (rs *rowSets) Close() error {
 	rs.invalidateRaw()
-	rs.ex.rowsWereClosed = true
+	rs.rowsWereClosed = true
 	return rs.sets[rs.pos].closeErr
 }
 
@@ -58,6 +60,18 @@ func (rs *rowSets) Next(dest []driver.Value) error {
 	}
 
 	return r.nextErr[r.pos-1]
+}
+
+func (rs *rowSets) WillBeClosed(closed bool) {
+	rs.rowsMustBeClosed = closed
+}
+
+func (rs *rowSets) AreClosed() bool {
+	return rs.rowsWereClosed
+}
+
+func (rs *rowSets) MustBeClosed() bool {
+	return rs.rowsMustBeClosed
 }
 
 // transforms to debuggable printable string

--- a/sqlmock.go
+++ b/sqlmock.go
@@ -202,8 +202,8 @@ func (c *sqlmock) ExpectationsWereMet() error {
 		}
 
 		// must check whether all expected queried rows are closed
-		if query, ok := e.(*ExpectedQuery); ok {
-			if query.rowsMustBeClosed && !query.rowsWereClosed {
+		if query, ok := e.(*ExpectedQuery); ok && query.rows != nil {
+			if query.rows.MustBeClosed() && !query.rows.AreClosed() {
 				return fmt.Errorf("expected query rows to be closed, but it was not: %s", query)
 			}
 		}

--- a/sqlmock.go
+++ b/sqlmock.go
@@ -179,7 +179,7 @@ func (c *sqlmock) Close() error {
 		return fmt.Errorf(msg)
 	}
 
-	expected.triggered = true
+	expected.times -= 1
 	expected.Unlock()
 	return expected.err
 }
@@ -253,7 +253,7 @@ func (c *sqlmock) begin() (*ExpectedBegin, error) {
 		return nil, fmt.Errorf(msg)
 	}
 
-	expected.triggered = true
+	expected.times -= 1
 	expected.Unlock()
 
 	return expected, expected.err
@@ -329,7 +329,7 @@ func (c *sqlmock) prepare(query string) (*ExpectedPrepare, error) {
 		return nil, fmt.Errorf("Prepare: %v", err)
 	}
 
-	expected.triggered = true
+	expected.times -= 1
 	return expected, expected.err
 }
 
@@ -389,7 +389,7 @@ func (c *sqlmock) Commit() error {
 		return fmt.Errorf(msg)
 	}
 
-	expected.triggered = true
+	expected.times -= 1
 	expected.Unlock()
 	return expected.err
 }
@@ -424,7 +424,7 @@ func (c *sqlmock) Rollback() error {
 		return fmt.Errorf(msg)
 	}
 
-	expected.triggered = true
+	expected.times -= 1
 	expected.Unlock()
 	return expected.err
 }

--- a/sqlmock_before_go18.go
+++ b/sqlmock_before_go18.go
@@ -97,7 +97,7 @@ func (c *sqlmock) query(query string, args []namedValue) (*ExpectedQuery, error)
 		return nil, fmt.Errorf("Query '%s', arguments do not match: %s", query, err)
 	}
 
-	expected.triggered = true
+	expected.times -= 1
 	if expected.err != nil {
 		return expected, expected.err // mocked to return error
 	}
@@ -178,7 +178,7 @@ func (c *sqlmock) exec(query string, args []namedValue) (*ExpectedExec, error) {
 		return nil, fmt.Errorf("ExecQuery '%s', arguments do not match: %s", query, err)
 	}
 
-	expected.triggered = true
+	expected.times -= 1
 	if expected.err != nil {
 		return expected, expected.err // mocked to return error
 	}

--- a/sqlmock_go18.go
+++ b/sqlmock_go18.go
@@ -148,7 +148,7 @@ func (c *sqlmock) ping() (*ExpectedPing, error) {
 		return nil, fmt.Errorf(msg)
 	}
 
-	expected.triggered = true
+	expected.times -= 1
 	expected.Unlock()
 	return expected, expected.err
 }
@@ -245,7 +245,8 @@ func (c *sqlmock) query(query string, args []driver.NamedValue) (*ExpectedQuery,
 		return nil, fmt.Errorf("Query '%s', arguments do not match: %s", query, err)
 	}
 
-	expected.triggered = true
+	expected.times -= 1
+	expected.resetRows()
 	if expected.err != nil {
 		return expected, expected.err // mocked to return error
 	}
@@ -327,7 +328,7 @@ func (c *sqlmock) exec(query string, args []driver.NamedValue) (*ExpectedExec, e
 		return nil, fmt.Errorf("ExecQuery '%s', arguments do not match: %s", query, err)
 	}
 
-	expected.triggered = true
+	expected.times -= 1
 	if expected.err != nil {
 		return expected, expected.err // mocked to return error
 	}

--- a/sqlmock_go18.go
+++ b/sqlmock_go18.go
@@ -246,7 +246,9 @@ func (c *sqlmock) query(query string, args []driver.NamedValue) (*ExpectedQuery,
 	}
 
 	expected.times -= 1
-	expected.resetRows()
+	if expected.rows != nil {
+		expected.resetRows()
+	}
 	if expected.err != nil {
 		return expected, expected.err // mocked to return error
 	}

--- a/sqlmock_go18_test.go
+++ b/sqlmock_go18_test.go
@@ -140,7 +140,8 @@ func TestContextExec(t *testing.T) {
 	defer db.Close()
 
 	mock.ExpectExec("DELETE FROM users").
-		WillReturnResult(NewResult(1, 1)).Times(3)
+		WillReturnResult(NewResult(1, 1)).
+		Times(3)
 
 	ctx, cancel := context.WithCancel(context.Background())
 


### PR DESCRIPTION
Added new "times" method which can set expectation to run same query multiple number of times. eg.

`	mock.ExpectExec("DELETE FROM users").
		WillReturnResult(NewResult(1, 1)).Times(3)`
will expect same query 3 times