### PR TITLE
Add Multi Row Support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,5 @@
 module github.com/DATA-DOG/go-sqlmock
+
+go 1.16
+
+require github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/DATA-DOG/go-sqlmock
 
-go 1.16
+go 1.15
 
 require github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46 h1:veS9QfglfvqAw2e+eeNT/SbGySq8ajECXJ9e4fPoLhY=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=

--- a/rows.go
+++ b/rows.go
@@ -188,6 +188,16 @@ func (r *Rows) AddRow(values ...driver.Value) *Rows {
 	return r
 }
 
+// AddRows adds multiple rows composed from database driver.Value slice and
+// returns the same instance to perform subsequent actions.
+func (r *Rows) AddRows(values ...[]driver.Value) *Rows {
+	for _, value := range values {
+		r.AddRow(value...)
+	}
+
+	return r
+}
+
 // FromCSVString build rows from csv string.
 // return the same instance to perform subsequent actions.
 // Note that the number of values must match the number

--- a/rows_test.go
+++ b/rows_test.go
@@ -717,7 +717,7 @@ func TestAddRows(t *testing.T) {
 	// scanned id: 4 and title: Emily
 }
 
-func ExampleMultiRows() {
+func ExampleRows_AddRows() {
 	db, mock, err := New()
 	if err != nil {
 		fmt.Println("failed to open sqlmock database:", err)


### PR DESCRIPTION
Closes #135

This PR adds the `AddRows` function to the API which will allow users to add multiple rows at once instead of calling `AddRow` multiple times.