### PR TITLE
Countermeasure for https://github.com/DATA-DOG/go-sqlmock/issues/239

### DIFF
--- a/sqlmock_before_go18.go
+++ b/sqlmock_before_go18.go
@@ -145,6 +145,11 @@ func (c *sqlmock) exec(query string, args []namedValue) (*ExpectedExec, error) {
 			if expected, ok = next.(*ExpectedExec); ok {
 				break
 			}
+            // Countermeasure for
+            // https://github.com/DATA-DOG/go-sqlmock/issues/239
+			if expected, ok = next.(*ExpectedQuery); ok {
+				break
+			}
 			next.Unlock()
 			return nil, fmt.Errorf("call to ExecQuery '%s' with args %+v, was not expected, next expectation is: %s", query, args, next)
 		}


### PR DESCRIPTION
According to https://github.com/DATA-DOG/go-sqlmock/issues/239
> Sqlmock is based on a standard sql driver interface. It will not try to adapt to different frameworks, which use it in non standard expected ways. So you can just fork it and customize