### PR TITLE
Add WillCompleteOnCancel expectation

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,8 @@ It only asserts that argument is of `time.Time` type.
 
 ## Change Log
 
+- **2022-08-25** - added **WillCompleteOnCancel** expectation to create the scenario where a context has been cancelled
+  but the database still completes the query without cancellation or error.
 - **2019-04-06** - added functionality to mock a sql MetaData request
 - **2019-02-13** - added `go.mod` removed the references and suggestions using `gopkg.in`.
 - **2018-12-11** - added expectation of Rows to be closed, while mocking expected query.

--- a/expectations.go
+++ b/expectations.go
@@ -53,7 +53,17 @@ func (e *ExpectedClose) String() string {
 // returned by *Sqlmock.ExpectBegin.
 type ExpectedBegin struct {
 	commonExpectation
-	delay time.Duration
+	completeOnCancel bool
+	delay            time.Duration
+}
+
+// WillCompleteOnCancel prevents context cancellation from cancelling the query and returning ErrCancelled.
+// Some databases may not guarantee that a query will be cancelled even if a cancellation signal is sent to the
+// database. In these cases there is an edge case where the context is cancelled but the query completes without error.
+// WillCompleteOnCancel facilitates testing this edge case.
+func (e *ExpectedBegin) WillCompleteOnCancel() *ExpectedBegin {
+	e.completeOnCancel = true
+	return e
 }
 
 // WillReturnError allows to set an error for *sql.DB.Begin action
@@ -129,6 +139,7 @@ type ExpectedQuery struct {
 	delay            time.Duration
 	rowsMustBeClosed bool
 	rowsWereClosed   bool
+	completeOnCancel bool
 }
 
 // WithArgs will match given expected args to actual database query arguments.
@@ -142,6 +153,15 @@ func (e *ExpectedQuery) WithArgs(args ...driver.Value) *ExpectedQuery {
 // RowsWillBeClosed expects this query rows to be closed.
 func (e *ExpectedQuery) RowsWillBeClosed() *ExpectedQuery {
 	e.rowsMustBeClosed = true
+	return e
+}
+
+// WillCompleteOnCancel prevents context cancellation from cancelling the query and returning ErrCancelled.
+// Some databases may not guarantee that a query will be cancelled even if a cancellation signal is sent to the
+// database. In these cases there is an edge case where the context is cancelled but the query completes without error.
+// WillCompleteOnCancel facilitates testing this edge case.
+func (e *ExpectedQuery) WillCompleteOnCancel() *ExpectedQuery {
+	e.completeOnCancel = true
 	return e
 }
 
@@ -188,8 +208,9 @@ func (e *ExpectedQuery) String() string {
 // Returned by *Sqlmock.ExpectExec.
 type ExpectedExec struct {
 	queryBasedExpectation
-	result driver.Result
-	delay  time.Duration
+	result           driver.Result
+	delay            time.Duration
+	completeOnCancel bool
 }
 
 // WithArgs will match given expected args to actual database exec operation arguments.
@@ -197,6 +218,15 @@ type ExpectedExec struct {
 // arguments an sqlmock.Argument interface can be used to match an argument.
 func (e *ExpectedExec) WithArgs(args ...driver.Value) *ExpectedExec {
 	e.args = args
+	return e
+}
+
+// WillCompleteOnCancel prevents context cancellation from cancelling the query and returning ErrCancelled.
+// Some databases may not guarantee that a query will be cancelled even if a cancellation signal is sent to the
+// database. In these cases there is an edge case where the context is cancelled but the query completes without error.
+// WillCompleteOnCancel facilitates testing this edge case.
+func (e *ExpectedExec) WillCompleteOnCancel() *ExpectedExec {
+	e.completeOnCancel = true
 	return e
 }
 
@@ -260,13 +290,23 @@ func (e *ExpectedExec) WillReturnResult(result driver.Result) *ExpectedExec {
 // Returned by *Sqlmock.ExpectPrepare.
 type ExpectedPrepare struct {
 	commonExpectation
-	mock         *sqlmock
-	expectSQL    string
-	statement    driver.Stmt
-	closeErr     error
-	mustBeClosed bool
-	wasClosed    bool
-	delay        time.Duration
+	mock             *sqlmock
+	expectSQL        string
+	statement        driver.Stmt
+	closeErr         error
+	mustBeClosed     bool
+	wasClosed        bool
+	completeOnCancel bool
+	delay            time.Duration
+}
+
+// WillCompleteOnCancel prevents context cancellation from cancelling the query and returning ErrCancelled.
+// Some databases may not guarantee that a query will be cancelled even if a cancellation signal is sent to the
+// database. In these cases there is an edge case where the context is cancelled but the query completes without error.
+// WillCompleteOnCancel facilitates testing this edge case.
+func (e *ExpectedPrepare) WillCompleteOnCancel() *ExpectedPrepare {
+	e.completeOnCancel = true
+	return e
 }
 
 // WillReturnError allows to set an error for the expected *sql.DB.Prepare or *sql.Tx.Prepare action.

--- a/sqlmock_go18.go
+++ b/sqlmock_go18.go
@@ -39,6 +39,9 @@ func (c *sqlmock) QueryContext(ctx context.Context, query string, args []driver.
 			}
 			return ex.rows, nil
 		case <-ctx.Done():
+			if ex.completeOnCancel {
+				return ex.rows, nil
+			}
 			return nil, ErrCancelled
 		}
 	}
@@ -57,6 +60,9 @@ func (c *sqlmock) ExecContext(ctx context.Context, query string, args []driver.N
 			}
 			return ex.result, nil
 		case <-ctx.Done():
+			if ex.completeOnCancel {
+				return ex.result, nil
+			}
 			return nil, ErrCancelled
 		}
 	}
@@ -75,6 +81,9 @@ func (c *sqlmock) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx
 			}
 			return c, nil
 		case <-ctx.Done():
+			if ex.completeOnCancel {
+				return c, nil
+			}
 			return nil, ErrCancelled
 		}
 	}
@@ -93,6 +102,9 @@ func (c *sqlmock) PrepareContext(ctx context.Context, query string) (driver.Stmt
 			}
 			return &statement{c, ex, query}, nil
 		case <-ctx.Done():
+			if ex.completeOnCancel {
+				return &statement{c, ex, query}, nil
+			}
 			return nil, ErrCancelled
 		}
 	}


### PR DESCRIPTION
Closes #299 

I nerd-sniped myself after writing up the issue and started looking into the code.  Turned out to be pretty straight-forward.  So here's a PR!  I hope you think it's useful.  If you decide to merge this I would certainly pull this update and use this feature to write some new tests.

The goal of `.WillCompleteOnCancel()` is to be able to test a pretty rare edge case in Postgres (and maybe other databases?) where the Go context is cancelled but due to timing, may not succeed in actually cancelling the query.  In this case the query completes without error, and functions like `QueryContext()` et al. do not return the "context canceled" error we normally expect.

This change is fully backward-compatible.  There is no change to the default behavior which is to return `ErrCancelled` when the context is cancelled.