### PR TITLE
Added SqlMock type to allow for options to be sent to function that creates the sqlmock

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -40,7 +40,7 @@ func (d *mockDriver) Open(dsn string) (driver.Conn, error) {
 // a specific driver.
 // Pings db so that all expectations could be
 // asserted.
-func New(options ...func(*sqlmock) error) (*sql.DB, Sqlmock, error) {
+func New(options ...SqlMockOption) (*sql.DB, Sqlmock, error) {
 	pool.Lock()
 	dsn := fmt.Sprintf("sqlmock_db_%d", pool.counter)
 	pool.counter++
@@ -67,7 +67,7 @@ func New(options ...func(*sqlmock) error) (*sql.DB, Sqlmock, error) {
 //
 // It is not recommended to use this method, unless you
 // really need it and there is no other way around.
-func NewWithDSN(dsn string, options ...func(*sqlmock) error) (*sql.DB, Sqlmock, error) {
+func NewWithDSN(dsn string, options ...SqlMockOption) (*sql.DB, Sqlmock, error) {
 	pool.Lock()
 	if _, ok := pool.conns[dsn]; ok {
 		pool.Unlock()

--- a/options.go
+++ b/options.go
@@ -2,9 +2,12 @@ package sqlmock
 
 import "database/sql/driver"
 
+// SqlMockOption is the type defining an option used to configure an SqlMock at creation
+type SqlMockOption func(*sqlmock) error
+
 // ValueConverterOption allows to create a sqlmock connection
 // with a custom ValueConverter to support drivers with special data types.
-func ValueConverterOption(converter driver.ValueConverter) func(*sqlmock) error {
+func ValueConverterOption(converter driver.ValueConverter) SqlMockOption {
 	return func(s *sqlmock) error {
 		s.converter = converter
 		return nil
@@ -14,7 +17,7 @@ func ValueConverterOption(converter driver.ValueConverter) func(*sqlmock) error 
 // QueryMatcherOption allows to customize SQL query matcher
 // and match SQL query strings in more sophisticated ways.
 // The default QueryMatcher is QueryMatcherRegexp.
-func QueryMatcherOption(queryMatcher QueryMatcher) func(*sqlmock) error {
+func QueryMatcherOption(queryMatcher QueryMatcher) SqlMockOption {
 	return func(s *sqlmock) error {
 		s.queryMatcher = queryMatcher
 		return nil
@@ -30,7 +33,7 @@ func QueryMatcherOption(queryMatcher QueryMatcher) func(*sqlmock) error {
 // If false is passed or this option is omitted, calls to Ping will not be
 // considered when determining expectations and calls to ExpectPing will have
 // no effect.
-func MonitorPingsOption(monitorPings bool) func(*sqlmock) error {
+func MonitorPingsOption(monitorPings bool) SqlMockOption {
 	return func(s *sqlmock) error {
 		s.monitorPings = monitorPings
 		return nil

--- a/sqlmock.go
+++ b/sqlmock.go
@@ -98,7 +98,7 @@ type sqlmock struct {
 	expected []expectation
 }
 
-func (c *sqlmock) open(options []func(*sqlmock) error) (*sql.DB, Sqlmock, error) {
+func (c *sqlmock) open(options []SqlMockOption) (*sql.DB, Sqlmock, error) {
 	db, err := sql.Open("sqlmock", c.dsn)
 	if err != nil {
 		return db, c, err


### PR DESCRIPTION
This PR addresses an issue where the user wants to embed the `SqlMock` creation code into a function, like so:

```
func createServiceMock(database string, schema string, opts ...sqlmock.SqlMockOption) (*MyDB, sqlmock.Sqlmock) {

	db, mock, err := sqlmock.New(opts...)
	Expect(err).ShouldNot(HaveOccurred())

	svc := FromConnection(database, schema, db)

	return svc, mock
}
```

With the current implementation of `go-sqlmock`, this cannot done because the option references a type internal to the `go-sqlmock` package. By adding an alias for this type, the user can now send such options without exposing the internal `sqlmock` type.