### PR TITLE
Fix Bug/285 - allow prepared statements to be prepared multiple times

### DIFF
--- a/sqlmock.go
+++ b/sqlmock.go
@@ -296,11 +296,16 @@ func (c *sqlmock) prepare(query string) (*ExpectedPrepare, error) {
 		if next.fulfilled() {
 			next.Unlock()
 			fulfilled++
-			continue
+			if _, ok = next.(*ExpectedPrepare); !ok {
+				continue
+			} else {
+				next.Lock()
+			}
 		}
 
 		if c.ordered {
 			if expected, ok = next.(*ExpectedPrepare); ok {
+				fulfilled--
 				break
 			}
 
@@ -311,6 +316,7 @@ func (c *sqlmock) prepare(query string) (*ExpectedPrepare, error) {
 		if pr, ok := next.(*ExpectedPrepare); ok {
 			if err := c.queryMatcher.Match(pr.expectSQL, query); err == nil {
 				expected = pr
+				fulfilled--
 				break
 			}
 		}
@@ -334,6 +340,13 @@ func (c *sqlmock) prepare(query string) (*ExpectedPrepare, error) {
 }
 
 func (c *sqlmock) ExpectPrepare(expectedSQL string) *ExpectedPrepare {
+	for _, e := range c.expected {
+		if ep, ok := e.(*ExpectedPrepare); ok {
+			if ep.expectSQL == expectedSQL {
+				return ep
+			}
+		}
+	}
 	e := &ExpectedPrepare{expectSQL: expectedSQL, mock: c}
 	c.expected = append(c.expected, e)
 	return e


### PR DESCRIPTION
I didn't see need to enable/disable this, so kept it as default behaviour.