### PR TITLE
WIP: Fix WillReturnRows(nil) in expectations_go18.go 

### DIFF
--- a/expectations_go18.go
+++ b/expectations_go18.go
@@ -16,7 +16,7 @@ func (e *ExpectedQuery) WillReturnRows(rows ...*Rows) *ExpectedQuery {
 	sets := make([]*Rows, len(rows))
 	for i, r := range rows {
 		sets[i] = r
-		if r.def != nil {
+		if r != nil && r.def != nil {
 			defs++
 		}
 	}

--- a/expectations_test.go
+++ b/expectations_test.go
@@ -101,3 +101,26 @@ func TestCustomValueConverterQueryScan(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestQueryWillReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	defer func() {
+		if err := recover(); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	mock.ExpectQuery("SELECT (.+) FROM users WHERE (.+)").WithArgs("test").WillReturnRows(nil)
+	query := "SELECT name, email FROM users WHERE name = ?"
+	_, err = mock.(*sqlmock).Query(query, []driver.Value{"test"})
+	if err != nil {
+		t.Error(err)
+	}
+}

--- a/expectations_test.go
+++ b/expectations_test.go
@@ -145,4 +145,5 @@ func TestQueryWillReturnsNil(t *testing.T) {
 	_, err = mock.(*sqlmock).Query(query, []driver.Value{"test"})
 	if err != nil {
 		t.Error(err)
+	}
 }


### PR DESCRIPTION
The addition of the resultset logic caused a nil pointer dereference panic whenever nil is used as an input.

This is a WIP PR. I intend to add a unit test for this.