### PR TITLE
fixes csv parse errors being silently ignored

### DIFF
--- a/rows.go
+++ b/rows.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"database/sql/driver"
 	"encoding/csv"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -208,8 +209,11 @@ func (r *Rows) FromCSVString(s string) *Rows {
 
 	for {
 		res, err := csvReader.Read()
-		if err != nil || res == nil {
-			break
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			panic(fmt.Sprintf("Parsing CSV string failed: %s", err.Error()))
 		}
 
 		row := make([]driver.Value, len(r.cols))

--- a/rows_test.go
+++ b/rows_test.go
@@ -461,6 +461,15 @@ func TestCSVRowParser(t *testing.T) {
 	}
 }
 
+func TestCSVParserInvalidInput(t *testing.T) {
+	defer func() {
+		recover()
+	}()
+	_ = NewRows([]string{"col1", "col2"}).FromCSVString("a,\"NULL\"\"")
+	// shouldn't reach here
+	t.Error("expected panic from parsing invalid CSV")
+}
+
 func TestWrongNumberOfValues(t *testing.T) {
 	// Open new mock database
 	db, mock, err := New()


### PR DESCRIPTION
Before this change the `FromCSVString` would return a subset of rows in case `csvReader.Read()` returns an error but ignore the error itself.
E.g.
```csv
one, two, three
one, two, "error""
```
The second line will result in a `ErrQuote` but the error is not handled. Instead the first row and no error are returned. This will then lead to undesired behavior of tests relying on this data.

The method `FromCSVString` already runs into a panic if the number of columns do not match. Therefore, I propose that an invalid input should run into a panic as well.

All errors returned by`csvreader.Read`, besides from `io.EOF`, should lead to a panic, as they indicate the csv string could not properly be parsed.