### PR TITLE
fix bug/285 parallel

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -45,7 +45,7 @@ func New(options ...func(*sqlmock) error) (*sql.DB, Sqlmock, error) {
 	dsn := fmt.Sprintf("sqlmock_db_%d", pool.counter)
 	pool.counter++
 
-	smock := &sqlmock{dsn: dsn, drv: pool, ordered: true}
+	smock := &sqlmock{dsn: dsn, drv: pool, ordered: true, expectedPrepareOnce: false}
 	pool.conns[dsn] = smock
 	pool.Unlock()
 

--- a/driver.go
+++ b/driver.go
@@ -45,7 +45,7 @@ func New(options ...func(*sqlmock) error) (*sql.DB, Sqlmock, error) {
 	dsn := fmt.Sprintf("sqlmock_db_%d", pool.counter)
 	pool.counter++
 
-	smock := &sqlmock{dsn: dsn, drv: pool, ordered: true, expectedPrepareOnce: false}
+	smock := &sqlmock{dsn: dsn, drv: pool, ordered: true}
 	pool.conns[dsn] = smock
 	pool.Unlock()
 

--- a/sqlmock.go
+++ b/sqlmock.go
@@ -84,6 +84,16 @@ type SqlmockCommon interface {
 	// sql driver.Value slice or from the CSV string and
 	// to be used as sql driver.Rows.
 	NewRows(columns []string) *Rows
+
+	// ExpectPreparedQueryOnce gives an option to control addition
+	// and match of queries passed via prepared statements in expectations.
+	// By default this is set to false.
+	//
+	// If you use goroutines to parallelize your query execution using
+	// prepared stmts, this option helps to avoid building multiple expectations
+	// for same query. Otherwise when set to true, already matched prepared or
+	// executed query may lead to generation of unexpected query matches.
+	ExpectPreparedQueryOnce(bool)
 }
 
 type sqlmock struct {
@@ -95,7 +105,8 @@ type sqlmock struct {
 	queryMatcher QueryMatcher
 	monitorPings bool
 
-	expected []expectation
+	expected            []expectation
+	expectedPrepareOnce bool
 }
 
 func (c *sqlmock) open(options []func(*sqlmock) error) (*sql.DB, Sqlmock, error) {
@@ -135,6 +146,10 @@ func (c *sqlmock) ExpectClose() *ExpectedClose {
 
 func (c *sqlmock) MatchExpectationsInOrder(b bool) {
 	c.ordered = b
+}
+
+func (c *sqlmock) ExpectPreparedQueryOnce(b bool) {
+	c.expectedPrepareOnce = b
 }
 
 // Close a mock database driver connection. It may or may not
@@ -296,6 +311,16 @@ func (c *sqlmock) prepare(query string) (*ExpectedPrepare, error) {
 		if next.fulfilled() {
 			next.Unlock()
 			fulfilled++
+
+			if c.expectedPrepareOnce {
+				if pr, ok := next.(*ExpectedPrepare); ok {
+					if err := c.queryMatcher.Match(pr.expectSQL, query); err == nil {
+						expected = pr
+						next.Lock()
+						break
+					}
+				}
+			}
 			continue
 		}
 
@@ -334,6 +359,16 @@ func (c *sqlmock) prepare(query string) (*ExpectedPrepare, error) {
 }
 
 func (c *sqlmock) ExpectPrepare(expectedSQL string) *ExpectedPrepare {
+	if c.expectedPrepareOnce {
+		for _, e := range c.expected {
+			if ep, ok := e.(*ExpectedPrepare); ok {
+				if ep.expectSQL == expectedSQL {
+					return ep
+				}
+			}
+		}
+	}
+
 	e := &ExpectedPrepare{expectSQL: expectedSQL, mock: c}
 	c.expected = append(c.expected, e)
 	return e

--- a/sqlmock_test.go
+++ b/sqlmock_test.go
@@ -672,9 +672,11 @@ func TestGoroutineExecutionWithUnorderedExpectationMatching(t *testing.T) {
 		t.Errorf("an error '%s' was not expected when opening a stub database connection", err)
 	}
 	defer db.Close()
-
 	// note this line is important for unordered expectation matching
 	mock.MatchExpectationsInOrder(false)
+
+	// note this line is needed for parallel query expectation matching.
+	mock.ExpectPreparedQueryOnce(true)
 
 	data := []interface{}{
 		1,

--- a/sqlmock_test.go
+++ b/sqlmock_test.go
@@ -672,6 +672,7 @@ func TestGoroutineExecutionWithUnorderedExpectationMatching(t *testing.T) {
 		t.Errorf("an error '%s' was not expected when opening a stub database connection", err)
 	}
 	defer db.Close()
+
 	// note this line is important for unordered expectation matching
 	mock.MatchExpectationsInOrder(false)
 

--- a/sqlmock_test.go
+++ b/sqlmock_test.go
@@ -675,9 +675,6 @@ func TestGoroutineExecutionWithUnorderedExpectationMatching(t *testing.T) {
 	// note this line is important for unordered expectation matching
 	mock.MatchExpectationsInOrder(false)
 
-	// note this line is needed for parallel query expectation matching.
-	mock.ExpectPreparedQueryOnce(true)
-
 	data := []interface{}{
 		1,
 		"John Doe",


### PR DESCRIPTION
added a fix in sqlmock Prepared stmt expectations building to avoid re-addition of same query to the common sqlmock expectation list. While executing mock prepare(), this will allow to consider already fulfilled query expectation in the expected match instead of throwing unexpected query error.