### PR TITLE
Modify: existing panic in AddRow to give a hint to the issue

### DIFF
--- a/rows.go
+++ b/rows.go
@@ -166,7 +166,7 @@ func (r *Rows) RowError(row int, err error) *Rows {
 // of columns
 func (r *Rows) AddRow(values ...driver.Value) *Rows {
 	if len(values) != len(r.cols) {
-		panic("Expected number of values to match number of columns")
+		panic(fmt.Sprintf("Expected number of values to match number of columns: expected %d, actual %d", len(values), len(r.cols)))
 	}
 
 	row := make([]driver.Value, len(r.cols))

--- a/rows_test.go
+++ b/rows_test.go
@@ -730,6 +730,31 @@ func TestAddRows(t *testing.T) {
 	// scanned id: 4 and title: Emily
 }
 
+func TestAddRowExpectPanic(t *testing.T) {
+	t.Parallel()
+
+	const expectedPanic = "Expected number of values to match number of columns: expected 1, actual 2"
+	values := []driver.Value{
+		"John",
+		"Jane",
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			if r != expectedPanic {
+				t.Fatalf("panic message did not match expected: expected '%s', actual '%s'", r, expectedPanic)
+			}
+
+			return
+		}
+		t.Fatalf("expected panic: %s", expectedPanic)
+	}()
+
+	rows := NewRows([]string{"id", "name"})
+	// Note missing spread "..."
+	rows.AddRow(values)
+}
+
 func ExampleRows_AddRows() {
 	db, mock, err := New()
 	if err != nil {


### PR DESCRIPTION
- Modify: existing panic in AddRow to give a hint to the issue
- Add: Test for panic.

I wrote a test for this as well. I tried to match the existing style of tests.

I hit this problem twice yesterday so I imagine it happens for others too. We use go-sqlmock a lot an I appreciate the work to maintain this project.

_Resolves_ https://github.com/DATA-DOG/go-sqlmock/issues/325
