### PR TITLE
fix: make no argument passed validation opt-in

### DIFF
--- a/expectations.go
+++ b/expectations.go
@@ -134,8 +134,24 @@ type ExpectedQuery struct {
 // WithArgs will match given expected args to actual database query arguments.
 // if at least one argument does not match, it will return an error. For specific
 // arguments an sqlmock.Argument interface can be used to match an argument.
+// Must not be used together with WithoutArgs()
 func (e *ExpectedQuery) WithArgs(args ...driver.Value) *ExpectedQuery {
+	if e.noArgs {
+		panic("WithArgs() and WithoutArgs() must not be used together")
+	}
 	e.args = args
+	return e
+}
+
+// WithoutArgs will ensure that no arguments are passed for this query.
+// if at least one argument is passed, it will return an error. This allows
+// for stricter validation of the query arguments.
+// Must no be used together with WithArgs()
+func (e *ExpectedQuery) WithoutArgs() *ExpectedQuery {
+	if len(e.args) > 0 {
+		panic("WithoutArgs() and WithArgs() must not be used together")
+	}
+	e.noArgs = true
 	return e
 }
 
@@ -195,8 +211,24 @@ type ExpectedExec struct {
 // WithArgs will match given expected args to actual database exec operation arguments.
 // if at least one argument does not match, it will return an error. For specific
 // arguments an sqlmock.Argument interface can be used to match an argument.
+// Must not be used together with WithoutArgs()
 func (e *ExpectedExec) WithArgs(args ...driver.Value) *ExpectedExec {
+	if len(e.args) > 0 {
+		panic("WithArgs() and WithoutArgs() must not be used together")
+	}
 	e.args = args
+	return e
+}
+
+// WithoutArgs will ensure that no args are passed for this expected database exec action.
+// if at least one argument is passed, it will return an error. This allows for stricter
+// validation of the query arguments.
+// Must not be used together with WithArgs()
+func (e *ExpectedExec) WithoutArgs() *ExpectedExec {
+	if len(e.args) > 0 {
+		panic("WithoutArgs() and WithArgs() must not be used together")
+	}
+	e.noArgs = true
 	return e
 }
 
@@ -338,6 +370,7 @@ type queryBasedExpectation struct {
 	expectSQL string
 	converter driver.ValueConverter
 	args      []driver.Value
+	noArgs    bool // ensure no args are passed
 }
 
 // ExpectedPing is used to manage *sql.DB.Ping expectations.

--- a/expectations_before_go18.go
+++ b/expectations_before_go18.go
@@ -1,3 +1,4 @@
+//go:build !go1.8
 // +build !go1.8
 
 package sqlmock
@@ -17,7 +18,7 @@ func (e *ExpectedQuery) WillReturnRows(rows *Rows) *ExpectedQuery {
 
 func (e *queryBasedExpectation) argsMatches(args []namedValue) error {
 	if nil == e.args {
-		if len(args) > 0 {
+		if e.noArgs && len(args) > 0 {
 			return fmt.Errorf("expected 0, but got %d arguments", len(args))
 		}
 		return nil

--- a/expectations_before_go18_test.go
+++ b/expectations_before_go18_test.go
@@ -1,3 +1,4 @@
+//go:build !go1.8
 // +build !go1.8
 
 package sqlmock
@@ -9,10 +10,15 @@ import (
 )
 
 func TestQueryExpectationArgComparison(t *testing.T) {
-	e := &queryBasedExpectation{converter: driver.DefaultParameterConverter}
+	e := &queryBasedExpectation{converter: driver.DefaultParameterConverter, noArgs: true}
 	against := []namedValue{{Value: int64(5), Ordinal: 1}}
 	if err := e.argsMatches(against); err == nil {
-		t.Error("arguments should not match, since no expectation was set, but argument was passed")
+		t.Error("arguments should not match, since argument was passed, but noArgs was set")
+	}
+
+	e.noArgs = false
+	if err := e.argsMatches(against); err != nil {
+		t.Error("arguments should match, since argument was passed, but no expected args or noArgs was set")
 	}
 
 	e.args = []driver.Value{5, "str"}

--- a/expectations_go18.go
+++ b/expectations_go18.go
@@ -1,3 +1,4 @@
+//go:build go1.8
 // +build go1.8
 
 package sqlmock
@@ -30,7 +31,7 @@ func (e *ExpectedQuery) WillReturnRows(rows ...*Rows) *ExpectedQuery {
 
 func (e *queryBasedExpectation) argsMatches(args []driver.NamedValue) error {
 	if nil == e.args {
-		if len(args) > 0 {
+		if e.noArgs && len(args) > 0 {
 			return fmt.Errorf("expected 0, but got %d arguments", len(args))
 		}
 		return nil

--- a/expectations_go18_test.go
+++ b/expectations_go18_test.go
@@ -1,3 +1,4 @@
+//go:build go1.8
 // +build go1.8
 
 package sqlmock
@@ -10,10 +11,15 @@ import (
 )
 
 func TestQueryExpectationArgComparison(t *testing.T) {
-	e := &queryBasedExpectation{converter: driver.DefaultParameterConverter}
+	e := &queryBasedExpectation{converter: driver.DefaultParameterConverter, noArgs: true}
 	against := []driver.NamedValue{{Value: int64(5), Ordinal: 1}}
 	if err := e.argsMatches(against); err == nil {
-		t.Error("arguments should not match, since no expectation was set, but argument was passed")
+		t.Error("arguments should not match, since argument was passed, but noArgs was set")
+	}
+
+	e.noArgs = false
+	if err := e.argsMatches(against); err != nil {
+		t.Error("arguments should match, since argument was passed, but no expected args or noArgs was set")
 	}
 
 	e.args = []driver.Value{5, "str"}
@@ -102,10 +108,15 @@ func TestQueryExpectationArgComparisonBool(t *testing.T) {
 }
 
 func TestQueryExpectationNamedArgComparison(t *testing.T) {
-	e := &queryBasedExpectation{converter: driver.DefaultParameterConverter}
+	e := &queryBasedExpectation{converter: driver.DefaultParameterConverter, noArgs: true}
 	against := []driver.NamedValue{{Value: int64(5), Name: "id"}}
 	if err := e.argsMatches(against); err == nil {
-		t.Errorf("arguments should not match, since no expectation was set, but argument was passed")
+		t.Error("arguments should not match, since argument was passed, but noArgs was set")
+	}
+
+	e.noArgs = false
+	if err := e.argsMatches(against); err != nil {
+		t.Error("arguments should match, since argument was passed, but no expected args or noArgs was set")
 	}
 
 	e.args = []driver.Value{

--- a/expectations_test.go
+++ b/expectations_test.go
@@ -101,3 +101,25 @@ func TestCustomValueConverterQueryScan(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestQueryWithNoArgsAndWithArgsPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			return
+		}
+		t.Error("Expected panic for using WithArgs and ExpectNoArgs together")
+	}()
+	mock := &sqlmock{}
+	mock.ExpectQuery("SELECT (.+) FROM user").WithArgs("John").WithoutArgs()
+}
+
+func TestExecWithNoArgsAndWithArgsPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			return
+		}
+		t.Error("Expected panic for using WithArgs and ExpectNoArgs together")
+	}()
+	mock := &sqlmock{}
+	mock.ExpectExec("^INSERT INTO user").WithArgs("John").WithoutArgs()
+}

--- a/sqlmock_go18_test.go
+++ b/sqlmock_go18_test.go
@@ -1,3 +1,4 @@
+//go:build go1.8
 // +build go1.8
 
 package sqlmock
@@ -437,7 +438,6 @@ func TestContextExecErrorDelay(t *testing.T) {
 	// test that return of error is delayed
 	var delay time.Duration = 100 * time.Millisecond
 	mock.ExpectExec("^INSERT INTO articles").
-		WithArgs("hello").
 		WillReturnError(errors.New("slow fail")).
 		WillDelayFor(delay)
 


### PR DESCRIPTION
https://github.com/DATA-DOG/go-sqlmock/pull/295 introduced stricter checking of query arguments. This results in new test failures when using e.g. `ExpectedQuery` or `ExpectedExec` without `WithArgs(..)` and the actual query passes arguments. This case of no expected arguments but actual arguments passed was previously not caught.

However, there is also the case where queries are matched via `QueryMatcherRegexp` and there is no intention to strictly validate the actual arguments. This case broke with the above mentioned change and requires rather cumbersome fixing as such:
 ```golang
// this would fail with arguments do not match: expected 0, but got 6 arguments
mock.ExpectExec("INSERT .*idp::idp.*").WillReturnResult(sqlmock.NewResult(0, 1))
...
// this would be the fix
mock.ExpectExec("INSERT .*idp::idp.*").WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(0, 1))
```

In order to allow for both strict and relaxed matching of the expectations this change adds `WithoutArgs()`. This new Method on `ExpectedQuery` and `ExpectedExec` allows to strictly ensure that the actual query does not pass any arguments.
This reverts the strict argument checking introduced with https://github.com/DATA-DOG/go-sqlmock/pull/295 and makes this behavior opt-in.
Furthermore, a test will panic if both `WithArgs(..)` and `WithoutArgs()` are used together.
