### PR TITLE
fix bug/334 when checking empty expectedQuery with actual query 

### DIFF
--- a/query.go
+++ b/query.go
@@ -43,6 +43,10 @@ func (f QueryMatcherFunc) Match(expectedSQL, actualSQL string) error {
 // used by sqlmock. It parses expectedSQL to a regular
 // expression and attempts to match actualSQL.
 var QueryMatcherRegexp QueryMatcher = QueryMatcherFunc(func(expectedSQL, actualSQL string) error {
+	if actual != "" and expect == "" {
+		return fmt.Errorf("expectedSQL can't be empty")
+	}
+	
 	expect := stripQuery(expectedSQL)
 	actual := stripQuery(actualSQL)
 	re, err := regexp.Compile(expect)

--- a/query.go
+++ b/query.go
@@ -42,13 +42,12 @@ func (f QueryMatcherFunc) Match(expectedSQL, actualSQL string) error {
 // QueryMatcherRegexp is the default SQL query matcher
 // used by sqlmock. It parses expectedSQL to a regular
 // expression and attempts to match actualSQL.
-var QueryMatcherRegexp QueryMatcher = QueryMatcherFunc(func(expectedSQL, actualSQL string) error {
-	if actual != "" and expect == "" {
-		return fmt.Errorf("expectedSQL can't be empty")
-	}
-	
+var QueryMatcherRegexp QueryMatcher = QueryMatcherFunc(func(expectedSQL, actualSQL string) error {	
 	expect := stripQuery(expectedSQL)
 	actual := stripQuery(actualSQL)
+	if actual != "" && expect == "" {
+		return fmt.Errorf("expectedSQL can't be empty")
+	}
 	re, err := regexp.Compile(expect)
 	if err != nil {
 		return err

--- a/query_test.go
+++ b/query_test.go
@@ -69,6 +69,7 @@ func TestQueryMatcherRegexp(t *testing.T) {
 		{"SELECT (.+) FROM users", "SELECT name, email FROM users WHERE id = ?", nil},
 		{"Select (.+) FROM users", "SELECT name, email FROM users WHERE id = ?", fmt.Errorf(`could not match actual sql: "SELECT name, email FROM users WHERE id = ?" with expected regexp "Select (.+) FROM users"`)},
 		{"SELECT (.+) FROM\nusers", "SELECT name, email\n FROM users\n WHERE id = ?", nil},
+                {"","SELECT from table", fmt.Errorf(`expectedSQL can't be empty`)},
 	}
 
 	for i, c := range cases {


### PR DESCRIPTION
If expected query is empty, it is matching against any string that is in actual and this fix should prevent that  