### PR TITLE
fix: correct typos in comments and error strings

### DIFF
--- a/rows_test.go
+++ b/rows_test.go
@@ -84,7 +84,7 @@ func ExampleRows_closeError() {
 
 	// Note: that close will return error only before rows EOF
 	// that is a default sql package behavior. If you run rs.Next()
-	// it will handle the error internally and return nil bellow
+	// it will handle the error internally and return nil below
 	if err := rs.Close(); err != nil {
 		fmt.Println("got error:", err)
 	}

--- a/sqlmock.go
+++ b/sqlmock.go
@@ -71,7 +71,7 @@ type SqlmockCommon interface {
 	// expectations in the order they were set or not.
 	//
 	// By default it is set to - true. But if you use goroutines
-	// to parallelize your query executation, that option may
+	// to parallelize your query execution, that option may
 	// be handy.
 	//
 	// This option may be turned on anytime during tests. As soon

--- a/sqlmock_test.go
+++ b/sqlmock_test.go
@@ -1175,7 +1175,7 @@ func TestNewRows(t *testing.T) {
 
 	r := mock.NewRows(columns)
 	if len(r.cols) != len(columns) || r.cols[0] != columns[0] || r.cols[1] != columns[1] {
-		t.Errorf("expecting to create a row with columns %v, actual colmns are %v", r.cols, columns)
+		t.Errorf("expecting to create a row with columns %v, actual columns are %v", r.cols, columns)
 	}
 }
 


### PR DESCRIPTION
Fix three typos found in .go files:

- `rows_test.go`: `bellow` -> `below`
- `sqlmock.go`: `executation` -> `execution`
- `sqlmock_test.go`: `colmns` -> `columns`

Found with `codespell`.